### PR TITLE
feat/i2c: Add I2C wrapper functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(cores)
+add_subdirectory(libraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(cores)
 add_subdirectory(libraries)

--- a/examples/button_press_led/sample.yaml
+++ b/examples/button_press_led/sample.yaml
@@ -1,9 +1,5 @@
 sample:
-<<<<<<< HEAD
   name: Button Press Sample
-=======
-  name: Blinky Sample
->>>>>>> ba84fd8 (gpio: adds basic digital i/o support)
 tests:
   sample.basic.blinky:
     tags: LED gpio

--- a/examples/button_press_led/sample.yaml
+++ b/examples/button_press_led/sample.yaml
@@ -1,5 +1,9 @@
 sample:
+<<<<<<< HEAD
   name: Button Press Sample
+=======
+  name: Blinky Sample
+>>>>>>> ba84fd8 (gpio: adds basic digital i/o support)
 tests:
   sample.basic.blinky:
     tags: LED gpio

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Wire)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(Wire)

--- a/libraries/Wire/CMakeLists.txt
+++ b/libraries/Wire/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+zephyr_include_directories(.)
+
+if(NOT DEFINED ARDUINO_BUILD_PATH)
+
+zephyr_sources(Wire.cpp)
+
+endif()

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "Wire.h"
 
 void arduino::ZephyrI2C::begin() {

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -1,0 +1,87 @@
+#include "Wire.h"
+
+void arduino::ZephyrI2C::begin() {
+  i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c0));
+  ring_buf_init(&rxRingBuffer.rb, sizeof(rxRingBuffer.buffer), rxRingBuffer.buffer);
+}
+
+void arduino::ZephyrI2C::begin(uint8_t slaveAddr) {
+
+}
+
+void arduino::ZephyrI2C::end() {}
+
+void arduino::ZephyrI2C::setClock(uint32_t freq) {}
+
+void arduino::ZephyrI2C::beginTransmission(uint8_t address) { // TODO for ADS1115
+  _address = address;
+  usedTxBuffer = 0;
+}
+
+uint8_t arduino::ZephyrI2C::endTransmission(bool stopBit) {
+  int ret = i2c_write(i2c_dev, txBuffer, usedTxBuffer, _address);
+  if (ret) {
+    return 1; // fail
+  }
+  return 0;
+}
+
+uint8_t arduino::ZephyrI2C::endTransmission(void) { // TODO for ADS1115
+  return endTransmission(true);
+}
+
+size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len,
+                                       bool stopBit) {
+  int ret = i2c_read(i2c_dev, rxRingBuffer.buffer, len, address);
+  if (ret != 0)
+  {
+    printk("\n\nERR: i2c burst read fails\n\n\n");
+    return 0;
+  }
+  ret = ring_buf_put(&rxRingBuffer.rb, rxRingBuffer.buffer, len);
+  if (ret == 0)
+  {
+    printk("\n\nERR: buff put fails\n\n\n");
+    return 0;
+  }
+  return len;
+}
+
+size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len) { // TODO for ADS1115
+  return requestFrom(address, len, true);
+}
+
+size_t arduino::ZephyrI2C::write(uint8_t data) {  // TODO for ADS1115
+  txBuffer[usedTxBuffer++] = data;
+  return 1;
+}
+
+size_t arduino::ZephyrI2C::write(const uint8_t *buffer, size_t size) {
+  return size;
+}
+
+int arduino::ZephyrI2C::read() {
+  uint8_t buf[1];
+  if (ring_buf_peek(&rxRingBuffer.rb, buf, 1) > 0) {
+        int ret = ring_buf_get(&rxRingBuffer.rb, buf, 1);
+        if (ret == 0) {
+          printk("\n\nERR: buff empty\n\n\n");
+            return 0;
+        }
+		return (int)buf[0];
+  }
+  return rxBuffer[0];
+}
+
+int arduino::ZephyrI2C::available() { // TODO for ADS1115 
+  return 1; 
+  }
+
+int arduino::ZephyrI2C::peek() { return 1; }
+
+void arduino::ZephyrI2C::flush() {}
+
+void arduino::ZephyrI2C::onReceive(voidFuncPtrParamInt cb) {}
+void arduino::ZephyrI2C::onRequest(voidFuncPtr cb) {}
+
+arduino::ZephyrI2C Wire;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -19,7 +19,7 @@ void arduino::ZephyrI2C::end() {}
 
 void arduino::ZephyrI2C::setClock(uint32_t freq) {}
 
-void arduino::ZephyrI2C::beginTransmission(uint8_t address) { // TODO for ADS1115
+void arduino::ZephyrI2C::beginTransmission(uint8_t address) {
   _address = address;
   usedTxBuffer = 0;
 }
@@ -32,7 +32,7 @@ uint8_t arduino::ZephyrI2C::endTransmission(bool stopBit) {
   return 0;
 }
 
-uint8_t arduino::ZephyrI2C::endTransmission(void) { // TODO for ADS1115
+uint8_t arduino::ZephyrI2C::endTransmission(void) {
   return endTransmission(true);
 }
 
@@ -53,11 +53,11 @@ size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len,
   return len;
 }
 
-size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len) { // TODO for ADS1115
+size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len) {
   return requestFrom(address, len, true);
 }
 
-size_t arduino::ZephyrI2C::write(uint8_t data) {  // TODO for ADS1115
+size_t arduino::ZephyrI2C::write(uint8_t data) {
   txBuffer[usedTxBuffer++] = data;
   return 1;
 }
@@ -79,11 +79,11 @@ int arduino::ZephyrI2C::read() {
   return rxBuffer[0];
 }
 
-int arduino::ZephyrI2C::available() { // TODO for ADS1115 
+int arduino::ZephyrI2C::available() { // TODO
   return 1; 
   }
 
-int arduino::ZephyrI2C::peek() { return 1; }
+int arduino::ZephyrI2C::peek() { return 1; }   // TODO
 
 void arduino::ZephyrI2C::flush() {}
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "api/ArduinoAPI.h"

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "api/ArduinoAPI.h"
+#include "api/HardwareI2C.h"
+#include "api/Print.h"
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/ring_buffer.h>
+
+typedef void (*voidFuncPtrParamInt)(int);
+
+namespace arduino {
+
+class ZephyrI2C : public HardwareI2C {
+public:
+  virtual void begin();
+  virtual void end();
+  virtual void begin(uint8_t address);
+  virtual void setClock(uint32_t freq);
+
+  virtual void beginTransmission(uint8_t address);
+  virtual uint8_t endTransmission(bool stopBit);
+  virtual uint8_t endTransmission(void);
+
+  virtual size_t requestFrom(uint8_t address, size_t len, bool stopBit);
+  virtual size_t requestFrom(uint8_t address, size_t len);
+
+  virtual void onReceive(void (*)(int));
+  virtual void onRequest(void (*)(void));
+
+  virtual size_t write(uint8_t data);
+  virtual size_t write(int data) { return write((uint8_t)data); };
+  virtual size_t write(const uint8_t *buffer, size_t size);
+  using Print::write;
+  virtual int read();
+  virtual int peek();
+  virtual void flush();
+  virtual int available();
+  const struct device *i2c_dev;
+  static struct i2c_dt_spec bus;
+
+private:
+  int _address;
+  uint8_t txBuffer[256], rxBuffer[256];
+  uint32_t usedTxBuffer;
+  struct rx_ring_buf{
+    struct ring_buf rb;
+    uint8_t buffer[256];
+  };
+  struct rx_ring_buf rxRingBuffer;
+};
+
+} // namespace arduino
+
+extern arduino::ZephyrI2C Wire;
+
+typedef arduino::ZephyrI2C TwoWire;


### PR DESCRIPTION
* Tested with a custom example for ADXL345 which can be found [here](https://github.com/DhruvaG2000/Arduino-Core-Zephyr/pull/5#issuecomment-1166949394)

* Follows latest licensing and directory structure

* uses ringBuffer

* TODO: Testing for multiple byte read/write

* TODO: Add i2c example if required

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>