### PR TITLE
feat: add particle xenon pinmap

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "api/ArduinoAPI.h"
 
 /* Zephyr libraries */

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -1,12 +1,11 @@
-/*
- * Copyright (c) 2022 Dhruva Gole
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
 #include "api/ArduinoAPI.h"
 
 /* Zephyr libraries */
+#ifdef CONFIG_BOARD_ARDUINO_NANO_33_BLE_SENSE 
 #include "arduino_nano_ble_sense_pinmap.h"
-#include <zephyr/drivers/gpio.h>
+#endif
+#ifdef CONFIG_BOARD_PARTICLE_XENON 
+#include "particle_xenon_pinmap.h"
+#endif
 #include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>

--- a/cores/arduino/particle_xenon_pinmap.h
+++ b/cores/arduino/particle_xenon_pinmap.h
@@ -1,4 +1,10 @@
 /*
+ * Copyright (c) 2022 Alvaro Viebrantz
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
 All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0
 */
 

--- a/cores/arduino/particle_xenon_pinmap.h
+++ b/cores/arduino/particle_xenon_pinmap.h
@@ -1,0 +1,17 @@
+/*
+All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0
+*/
+
+enum digitalPins{
+D0 = 26,
+D1 = 27,
+D2 = 101,
+D3 = 102,
+D4 = 108,
+D5 = 110,
+D6 = 111,
+D7 = 112,
+D8 = 103
+};
+
+#define LED_BUILTIN 112


### PR DESCRIPTION
I changed things so the pinmap file is added depending on the target board.