### PR TITLE
samples: threads: fix build errors

### DIFF
--- a/samples/threads_arduino/CMakeLists.txt
+++ b/samples/threads_arduino/CMakeLists.txt
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
+
+set(DTC_OVERLAY_FILE $ENV{HOME}/zephyrproject/modules/lib/Arduino-Zephyr-API/variants/ARDUINO_NANO33BLE/arduino_nano_33_ble.overlay)
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(threads)
 
 target_sources(app PRIVATE src/main.cpp)
+zephyr_compile_options(-Wno-unused-variable -Wno-comment)


### PR DESCRIPTION
The CMakelists file did not specify the overlay and hence the nodes in the header files were nowhere to be found.
This commit fixes the issue by adding the overlay file, and also adds other flags that help eliminate unused var warnings

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>