### PR TITLE
variants: add support for arduino_mkrzero

### DIFF
--- a/variants/arduino_mkrzero/arduino_mkrzero.overlay
+++ b/variants/arduino_mkrzero/arduino_mkrzero.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole <goledhruva@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	zephyr,user {
+		d0_gpios = <&arduino_mkr_header 0 0>;
+		d1_gpios = <&arduino_mkr_header 1 0>;
+		d2_gpios = <&arduino_mkr_header 2 0>;
+		d3_gpios = <&arduino_mkr_header 3 0>;
+		d4_gpios = <&arduino_mkr_header 4 0>;
+		d5_gpios = <&arduino_mkr_header 5 0>;
+		d6_gpios = <&arduino_mkr_header 6 0>;
+		d7_gpios = <&arduino_mkr_header 7 0>;
+		d8_gpios = <&arduino_mkr_header 8 0>;
+		d9_gpios = <&arduino_mkr_header 9 0>;
+		d10_gpios = <&arduino_mkr_header 10 0>;
+		d11_gpios = <&arduino_mkr_header  11 0>;
+		d12_gpios = <&arduino_mkr_header 12 0>;
+		d13_gpios = <&arduino_mkr_header 13 0>;
+		d14_gpios = <&arduino_mkr_header 14 0>; /* D14 / A0 */
+		d15_gpios = <&arduino_mkr_header 15 0>;
+		d16_gpios = <&arduino_mkr_header 16 0>;
+		d17_gpios = <&arduino_mkr_header 17 0>;
+		d18_gpios = <&arduino_mkr_header 18 0>; /* D18 / A4 / I2C-SDA */
+		d19_gpios = <&arduino_mkr_header 19 0>; /* D19 / A5 / I2C-SCL */
+		d20_gpios = <&arduino_mkr_header 20 0>;
+		d21_gpios = <&arduino_mkr_header 21 0>;
+	};
+};

--- a/variants/arduino_mkrzero/arduino_mkrzero_pinmap.h
+++ b/variants/arduino_mkrzero/arduino_mkrzero_pinmap.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i2c.h>
+
+#define LED_BUILTIN 22
+#define LED0_NODE DT_ALIAS(led0)
+
+static struct gpio_dt_spec d0 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d0_gpios);
+static struct gpio_dt_spec d1 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d1_gpios);
+static struct gpio_dt_spec d2 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d2_gpios);
+static struct gpio_dt_spec d3 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d3_gpios);
+static struct gpio_dt_spec d4 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d4_gpios);
+static struct gpio_dt_spec d5 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d5_gpios);
+static struct gpio_dt_spec d6 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d6_gpios);
+static struct gpio_dt_spec d7 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d7_gpios);
+static struct gpio_dt_spec d8 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d8_gpios);
+static struct gpio_dt_spec d9 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d9_gpios);
+static struct gpio_dt_spec d10 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d10_gpios);
+static struct gpio_dt_spec d11 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d11_gpios);
+static struct gpio_dt_spec d12 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d12_gpios);
+static struct gpio_dt_spec d13 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d13_gpios);
+static struct gpio_dt_spec d14 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d13_gpios);
+static struct gpio_dt_spec d15 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d15_gpios);
+static struct gpio_dt_spec d16 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d16_gpios);
+static struct gpio_dt_spec d17 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d17_gpios);
+static struct gpio_dt_spec d18 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d18_gpios);
+static struct gpio_dt_spec d19 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d19_gpios);
+static struct gpio_dt_spec d20 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d20_gpios);
+static struct gpio_dt_spec d21 =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d21_gpios);
+static struct gpio_dt_spec led_builtin = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+static struct gpio_dt_spec *arduino_pins[23] = {
+    &d0,  &d1,  &d2,  &d3,  &d4,  &d5,  &d6,         &d7,
+    &d8,  &d9,  &d10, &d11, &d12, &d13, &d14,        &d15,
+    &d16, &d17, &d18, &d19, &d20, &d21, &led_builtin};
+
+enum digitalPins {
+  D0,
+  D1,
+  D2,
+  D3,
+  D4,
+  D5,
+  D6,
+  D7,
+  D8,
+  D9,
+  D10,
+  D11,
+  D12,
+  D13,
+  D14,
+  D15,
+  D16,
+  D17,
+  D18,
+  D19,
+  D20,
+  D21,
+  LED
+};
+
+const static struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(sercom0));

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -10,3 +10,7 @@
 #ifdef CONFIG_BOARD_NRF52840DK_NRF52840
 #include "nrf52840dk_nrf52840_pinmap.h"
 #endif /* CONFIG_BOARD_NRF52840DK_NRF52840 */
+#ifdef CONFIG_BOARD_ARDUINO_MKRZERO
+#include "arduino_mkrzero_pinmap.h"
+#endif // CONFIG_BOARD_ARDUINO_MKRZERO
+


### PR DESCRIPTION
Adds support for the arduino mkr zero board. Tested with LED_Blink sample.
I am not sure about the inbuilt LED pin number though, hence this pinmap just uses D7 for
demo purposes

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>