### PR TITLE
Add micros() and millis() functions

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -38,3 +38,10 @@ PinStatus digitalRead(pin_size_t pinNumber) {
 void delay(unsigned long ms) { k_sleep(K_MSEC(ms)); }
 
 void delayMicroseconds(unsigned int us) { k_sleep(K_USEC(us)); }
+
+unsigned long micros(void) {
+  return k_cyc_to_us_floor32(k_cycle_get_32());
+}
+
+unsigned long millis(void) { return k_uptime_get_32(); }
+


### PR DESCRIPTION
Wraps Zephyr kernel timing calls in Arduino API. This completes the Arduino Time functions.