### PR TITLE
zephyrCommon: Implement yield()

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "Arduino.h"
+#include <Arduino.h>
+
+void yield(void) {
+  k_yield();
+}
 
 /*
  *  The ACTIVE_HIGH flag is set so that A low physical


### PR DESCRIPTION
* Fixes https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core/issues/40
* yield(): causes the current thread to yield execution to another thread of the same or higher priority.
If there are no other ready threads of the same or higher priority, the routine returns immediately.
* Also replace include Arduino "" with <>.

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>