### PR TITLE
include kernel.h instead of zephyr.h

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -7,7 +7,7 @@
 #include "api/ArduinoAPI.h"
 
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <variants.h>
 #include <zephyrSerial.h>

--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble_pinmap.h
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble_pinmap.h
@@ -7,7 +7,7 @@
 /* All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0 */
 #pragma once
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/device.h>
 

--- a/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense_pinmap.h
+++ b/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense_pinmap.h
@@ -7,7 +7,7 @@
 /* All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0 */
 #pragma once
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/device.h>
 

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot_pinmap.h
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot_pinmap.h
@@ -7,7 +7,7 @@
 /* All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0 */
 #pragma once
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/device.h>
 

--- a/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840_pinmap.h
+++ b/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840_pinmap.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #define LED_BUILTIN 22
 


### PR DESCRIPTION
The zephyr.h is already deprecated.
Use kernel.h instead of it.