### PR TITLE
variants: arduino_nano_33_iot: Fix 'i2c0' fail to resolve

### DIFF
--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot_pinmap.h
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot_pinmap.h
@@ -83,4 +83,5 @@ enum digitalPins {
   D21
 };
 
-const static struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c0));
+const static struct device *i2c_dev =
+			DEVICE_DT_GET(DT_NODELABEL(arduino_nano_i2c));


### PR DESCRIPTION
Use arduino_nano_i2c instead of i2c0.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>