### PR TITLE
variants: Introduce a digital-pins array to define digital pin

### DIFF
--- a/documentation/variants.md
+++ b/documentation/variants.md
@@ -50,7 +50,7 @@ variants/
 ### DeviceTree Overlay files for Arduino boards
 
 This module requires that your Arduino header pins be mapped in the DeviceTree
-to a `zephyr,user` node using the `d0_gpios` format for each pin. Follow the
+to 'digital-pin-gpios' array that child of a `zephyr,user` node. Follow the
 examples in the variants directory to create an overlay file and a header file
 for your board.
 
@@ -68,17 +68,18 @@ uses [the Arduino header definitions](https://github.com/zephyrproject-rtos/zeph
 ```
 / {
 	zephyr,user {
-		d0_gpios = <&arduino_header 6 0>;			/* Digital */
-		d1_gpios = <&arduino_header 7 0>;
-		...
-		d13_gpios = <&arduino_header 19 0>;
-		d14_gpios = <&arduino_header 0 0>;			/* Analog */
-		d15_gpios = <&arduino_header 1 0>;
-		...
-		d19_gpios = <&arduino_header 5 0>;
-		d20_gpios = <&arduino_header 20 0>;			/* SDA */
-		d21_gpios = <&arduino_header 21 0>;			/* SCL */
-		d22_gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;	/* LED0 */
+		digital-pin-gpios = <&arduino_header 6 0>,	/* Digital */
+				    <&arduino_header 7 0>;
+				    ...
+				    <&arduino_header 19 0>;
+				    <&arduino_header 0 0>;	/* Analog */
+				    <&arduino_header 1 0>;
+				    ...
+				    <&arduino_header 5 0>;
+				    <&arduino_header 20 0>;	/* SDA */
+				    <&arduino_header 21 0>;	/* SCL */
+				    <&gpio0 13 GPIO_ACTIVE_LOW>;	/* LED0 */
+		};
 	};
 };
 ```

--- a/variants/arduino_mkrzero/arduino_mkrzero.overlay
+++ b/variants/arduino_mkrzero/arduino_mkrzero.overlay
@@ -8,28 +8,28 @@
 
 / {
 	zephyr,user {
-		d0_gpios = <&arduino_mkr_header 0 0>;
-		d1_gpios = <&arduino_mkr_header 1 0>;
-		d2_gpios = <&arduino_mkr_header 2 0>;
-		d3_gpios = <&arduino_mkr_header 3 0>;
-		d4_gpios = <&arduino_mkr_header 4 0>;
-		d5_gpios = <&arduino_mkr_header 5 0>;
-		d6_gpios = <&arduino_mkr_header 6 0>;
-		d7_gpios = <&arduino_mkr_header 7 0>;
-		d8_gpios = <&arduino_mkr_header 8 0>;
-		d9_gpios = <&arduino_mkr_header 9 0>;
-		d10_gpios = <&arduino_mkr_header 10 0>;
-		d11_gpios = <&arduino_mkr_header  11 0>;
-		d12_gpios = <&arduino_mkr_header 12 0>;
-		d13_gpios = <&arduino_mkr_header 13 0>;
-		d14_gpios = <&arduino_mkr_header 14 0>; /* D14 / A0 */
-		d15_gpios = <&arduino_mkr_header 15 0>;
-		d16_gpios = <&arduino_mkr_header 16 0>;
-		d17_gpios = <&arduino_mkr_header 17 0>;
-		d18_gpios = <&arduino_mkr_header 18 0>; /* D18 / A4 / I2C-SDA */
-		d19_gpios = <&arduino_mkr_header 19 0>; /* D19 / A5 / I2C-SCL */
-		d20_gpios = <&arduino_mkr_header 20 0>;
-		d21_gpios = <&arduino_mkr_header 21 0>;
+		digital-pin-gpios = <&arduino_mkr_header 0 0>,
+				    <&arduino_mkr_header 1 0>,
+				    <&arduino_mkr_header 2 0>,
+				    <&arduino_mkr_header 3 0>,
+				    <&arduino_mkr_header 4 0>,
+				    <&arduino_mkr_header 5 0>,
+				    <&arduino_mkr_header 6 0>,
+				    <&arduino_mkr_header 7 0>,
+				    <&arduino_mkr_header 8 0>,
+				    <&arduino_mkr_header 9 0>,
+				    <&arduino_mkr_header 10 0>,
+				    <&arduino_mkr_header 11 0>,
+				    <&arduino_mkr_header 12 0>,
+				    <&arduino_mkr_header 13 0>,
+				    <&arduino_mkr_header 14 0>, /* D14 / A0 */
+				    <&arduino_mkr_header 15 0>,
+				    <&arduino_mkr_header 16 0>,
+				    <&arduino_mkr_header 17 0>,
+				    <&arduino_mkr_header 18 0>, /* D18 / A4 / I2C-SDA */
+				    <&arduino_mkr_header 19 0>, /* D19 / A5 / I2C-SCL */
+				    <&arduino_mkr_header 20 0>,
+				    <&arduino_mkr_header 21 0>;
 
 		pwms =	<&tcc0 2 255>,
 			<&tcc0 3 255>;

--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
@@ -1,27 +1,27 @@
 / {
 	zephyr,user {
-		d0_gpios = <&arduino_nano_header 0 0>;
-		d1_gpios = <&arduino_nano_header 1 0>;
-		d2_gpios = <&arduino_nano_header 2 0>;
-		d3_gpios = <&arduino_nano_header 3 0>;
-		d4_gpios = <&arduino_nano_header 4 0>;
-		d5_gpios = <&arduino_nano_header 5 0>;
-		d6_gpios = <&arduino_nano_header 6 0>;
-		d7_gpios = <&arduino_nano_header 7 0>;
-		d8_gpios = <&arduino_nano_header 8 0>;
-		d9_gpios = <&arduino_nano_header 9 0>;
-		d10_gpios = <&arduino_nano_header 10 0>;
-		d11_gpios = <&arduino_nano_header 11 0>;
-		d12_gpios = <&arduino_nano_header 12 0>;
-		d13_gpios = <&arduino_nano_header 13 0>;
-		d14_gpios = <&arduino_nano_header 14 0>; /* D14 / A0 */
-		d15_gpios = <&arduino_nano_header 15 0>;
-		d16_gpios = <&arduino_nano_header 16 0>;
-		d17_gpios = <&arduino_nano_header 17 0>;
-		d18_gpios = <&arduino_nano_header 18 0>; /* D18 / A4 / I2C-SDA */
-		d19_gpios = <&arduino_nano_header 19 0>; /* D19 / A5 / I2C-SCL */
-		d20_gpios = <&arduino_nano_header 20 0>;
-		d21_gpios = <&arduino_nano_header 21 0>;
+		digital-pin-gpios = <&arduino_nano_header 0 0>,
+				    <&arduino_nano_header 1 0>,
+				    <&arduino_nano_header 2 0>,
+				    <&arduino_nano_header 3 0>,
+				    <&arduino_nano_header 4 0>,
+				    <&arduino_nano_header 5 0>,
+				    <&arduino_nano_header 6 0>,
+				    <&arduino_nano_header 7 0>,
+				    <&arduino_nano_header 8 0>,
+				    <&arduino_nano_header 9 0>,
+				    <&arduino_nano_header 10 0>,
+				    <&arduino_nano_header 11 0>,
+				    <&arduino_nano_header 12 0>,
+				    <&arduino_nano_header 13 0>,
+				    <&arduino_nano_header 14 0>, /* D14 / A0 */
+				    <&arduino_nano_header 15 0>,
+				    <&arduino_nano_header 16 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 18 0>, /* D18 / A4 / I2C-SDA */
+				    <&arduino_nano_header 19 0>, /* D19 / A5 / I2C-SCL */
+				    <&arduino_nano_header 20 0>,
+				    <&arduino_nano_header 21 0>;
 
 		pwms =	<&pwm1 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 2 255 PWM_POLARITY_NORMAL>,

--- a/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense.overlay
+++ b/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense.overlay
@@ -1,27 +1,27 @@
 / {
 	zephyr,user {
-		d0_gpios = <&arduino_nano_header 0 0>;
-		d1_gpios = <&arduino_nano_header 1 0>;
-		d2_gpios = <&arduino_nano_header 2 0>;
-		d3_gpios = <&arduino_nano_header 3 0>;
-		d4_gpios = <&arduino_nano_header 4 0>;
-		d5_gpios = <&arduino_nano_header 5 0>;
-		d6_gpios = <&arduino_nano_header 6 0>;
-		d7_gpios = <&arduino_nano_header 7 0>;
-		d8_gpios = <&arduino_nano_header 8 0>;
-		d9_gpios = <&arduino_nano_header 9 0>;
-		d10_gpios = <&arduino_nano_header 10 0>;
-		d11_gpios = <&arduino_nano_header 11 0>;
-		d12_gpios = <&arduino_nano_header 12 0>;
-		d13_gpios = <&arduino_nano_header 13 0>;
-		d14_gpios = <&arduino_nano_header 14 0>; /* D14 / A0 */
-		d15_gpios = <&arduino_nano_header 15 0>;
-		d16_gpios = <&arduino_nano_header 16 0>;
-		d17_gpios = <&arduino_nano_header 17 0>;
-		d18_gpios = <&arduino_nano_header 18 0>; /* D18 / A4 / I2C-SDA */
-		d19_gpios = <&arduino_nano_header 19 0>; /* D19 / A5 / I2C-SCL */
-		d20_gpios = <&arduino_nano_header 20 0>;
-		d21_gpios = <&arduino_nano_header 21 0>;
+		digital-pin-gpios = <&arduino_nano_header 0 0>,
+				    <&arduino_nano_header 1 0>,
+				    <&arduino_nano_header 2 0>,
+				    <&arduino_nano_header 3 0>,
+				    <&arduino_nano_header 4 0>,
+				    <&arduino_nano_header 5 0>,
+				    <&arduino_nano_header 6 0>,
+				    <&arduino_nano_header 7 0>,
+				    <&arduino_nano_header 8 0>,
+				    <&arduino_nano_header 9 0>,
+				    <&arduino_nano_header 10 0>,
+				    <&arduino_nano_header 11 0>,
+				    <&arduino_nano_header 12 0>,
+				    <&arduino_nano_header 13 0>,
+				    <&arduino_nano_header 14 0>, /* D14 / A0 */
+				    <&arduino_nano_header 15 0>,
+				    <&arduino_nano_header 16 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 18 0>, /* D18 / A4 / I2C-SDA */
+				    <&arduino_nano_header 19 0>, /* D19 / A5 / I2C-SCL */
+				    <&arduino_nano_header 20 0>,
+				    <&arduino_nano_header 21 0>;
 
 		pwms =	<&pwm1 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 2 255 PWM_POLARITY_NORMAL>,

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
@@ -2,28 +2,28 @@
 
 / {
 	zephyr,user {
-		d0_gpios = <&arduino_nano_header 0 0>;
-		d1_gpios = <&arduino_nano_header 1 0>;
-		d2_gpios = <&arduino_nano_header 2 0>;
-		d3_gpios = <&arduino_nano_header 3 0>;
-		d4_gpios = <&arduino_nano_header 4 0>;
-		d5_gpios = <&arduino_nano_header 5 0>;
-		d6_gpios = <&arduino_nano_header 6 0>;
-		d7_gpios = <&arduino_nano_header 7 0>;
-		d8_gpios = <&arduino_nano_header 8 0>;
-		d9_gpios = <&arduino_nano_header 9 0>;
-		d10_gpios = <&arduino_nano_header 10 0>;
-		d11_gpios = <&arduino_nano_header 11 0>;
-		d12_gpios = <&arduino_nano_header 12 0>;
-		d13_gpios = <&arduino_nano_header 13 0>;
-		d14_gpios = <&arduino_nano_header 14 0>; /* D14 / A0 */
-		d15_gpios = <&arduino_nano_header 15 0>;
-		d16_gpios = <&arduino_nano_header 16 0>;
-		d17_gpios = <&arduino_nano_header 17 0>;
-		d18_gpios = <&arduino_nano_header 18 0>; /* D18 / A4 / I2C-SDA */
-		d19_gpios = <&arduino_nano_header 19 0>; /* D19 / A5 / I2C-SCL */
-		d20_gpios = <&arduino_nano_header 20 0>;
-		d21_gpios = <&arduino_nano_header 21 0>;
+		digital-pin-gpios = <&arduino_nano_header 0 0>,
+				    <&arduino_nano_header 1 0>,
+				    <&arduino_nano_header 2 0>,
+				    <&arduino_nano_header 3 0>,
+				    <&arduino_nano_header 4 0>,
+				    <&arduino_nano_header 5 0>,
+				    <&arduino_nano_header 6 0>,
+				    <&arduino_nano_header 7 0>,
+				    <&arduino_nano_header 8 0>,
+				    <&arduino_nano_header 9 0>,
+				    <&arduino_nano_header 10 0>,
+				    <&arduino_nano_header 11 0>,
+				    <&arduino_nano_header 12 0>,
+				    <&arduino_nano_header 13 0>,
+				    <&arduino_nano_header 14 0>, /* D14 / A0 */
+				    <&arduino_nano_header 15 0>,
+				    <&arduino_nano_header 16 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 18 0>, /* D18 / A4 / I2C-SDA */
+				    <&arduino_nano_header 19 0>, /* D19 / A5 / I2C-SCL */
+				    <&arduino_nano_header 20 0>,
+				    <&arduino_nano_header 21 0>;
 
 		pwms =	<&tcc0 0 255>,
 			<&tcc0 1 255>,

--- a/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
+++ b/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
@@ -1,28 +1,28 @@
 / {
 	zephyr,user {
-		d0_gpios = <&arduino_header 6 0>;	/* Digital */
-		d1_gpios = <&arduino_header 7 0>;
-		d2_gpios = <&arduino_header 8 0>;
-		d3_gpios = <&arduino_header 9 0>;
-		d4_gpios = <&arduino_header 10 0>;
-		d5_gpios = <&arduino_header 11 0>;
-		d6_gpios = <&arduino_header 12 0>;
-		d7_gpios = <&arduino_header 13 0>;
-		d8_gpios = <&arduino_header 14 0>;
-		d9_gpios = <&arduino_header 15 0>;
-		d10_gpios = <&arduino_header 16 0>;
-		d11_gpios = <&arduino_header 17 0>;
-		d12_gpios = <&arduino_header 18 0>;
-		d13_gpios = <&arduino_header 19 0>;
-		d14_gpios = <&arduino_header 20 0>;
-		d15_gpios = <&arduino_header 21 0>;
-		d16_gpios = <&arduino_header 0 0>;	/* Analog */
-		d17_gpios = <&arduino_header 1 0>;
-		d18_gpios = <&arduino_header 2 0>;
-		d19_gpios = <&arduino_header 3 0>;
-		d20_gpios = <&arduino_header 4 0>;
-		d21_gpios = <&arduino_header 5 0>;
-		d22_gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		digital-pin-gpios = <&arduino_header 6 0>,	/* Digital */
+				    <&arduino_header 7 0>,
+				    <&arduino_header 8 0>,
+				    <&arduino_header 9 0>,
+				    <&arduino_header 10 0>,
+				    <&arduino_header 11 0>,
+				    <&arduino_header 12 0>,
+				    <&arduino_header 13 0>,
+				    <&arduino_header 14 0>,
+				    <&arduino_header 15 0>,
+				    <&arduino_header 16 0>,
+				    <&arduino_header 17 0>,
+				    <&arduino_header 18 0>,
+				    <&arduino_header 19 0>,
+				    <&arduino_header 20 0>,
+				    <&arduino_header 21 0>,
+				    <&arduino_header 0 0>,	/* Analog */
+				    <&arduino_header 1 0>,
+				    <&arduino_header 2 0>,
+				    <&arduino_header 3 0>,
+				    <&arduino_header 4 0>,
+				    <&arduino_header 5 0>,
+				    <&gpio0 13 GPIO_ACTIVE_LOW>;
 
 		pwms =	<&pwm0 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm0 2 255 PWM_POLARITY_NORMAL>,

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -18,6 +18,24 @@
 #include "arduino_mkrzero_pinmap.h"
 #endif // CONFIG_BOARD_ARDUINO_MKRZERO
 
+#define DIGITAL_PIN_EXISTS(n, p, i, dev, num)                                                      \
+	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) &&                                      \
+	  (num == DT_PHA_BY_IDX(n, p, i, pin)))                                                    \
+		 ? 1                                                                               \
+		 : 0)
+
+#define DIGITAL_PIN_CHECK_UNIQUE(i, _)                                                             \
+	((DT_FOREACH_PROP_ELEM_SEP_VARGS(                                                          \
+		 DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS, (+),                 \
+		 DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), digital_pin_gpios, i)),       \
+		 DT_PHA_BY_IDX(DT_PATH(zephyr_user), digital_pin_gpios, i, pin))) == 1)
+
+#if !LISTIFY(DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios), DIGITAL_PIN_CHECK_UNIQUE, (&&))
+#error "digital_pin_gpios has duplicate definition"
+#endif
+
+#undef DIGITAL_PIN_CHECK_UNIQUE
+
 #define DN_ENUMS(n, p, i) D##i = i
 
 /*

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -18,32 +18,19 @@
 #include "arduino_mkrzero_pinmap.h"
 #endif // CONFIG_BOARD_ARDUINO_MKRZERO
 
-#define MAX_DIGITAL_PINS 255
-
-#define DN_ENUMS(n, _) COND_CODE_1(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), \
-			d ## n ## _gpios), (D ## n ,), ())
-
-#define LABEL_UPPER_TOKEN_COMMA(nodeid) DT_STRING_UPPER_TOKEN(nodeid, label),
+#define DN_ENUMS(n, p, i) D##i = i
 
 /*
  * expand as
  * enum digitalPins { D0, D1, ... LED... NUM_OF_DIGITAL_PINS };
  */
-enum digitalPins { LISTIFY(MAX_DIGITAL_PINS, DN_ENUMS, ())
-		   DT_FOREACH_CHILD(DT_PATH(leds), LABEL_UPPER_TOKEN_COMMA)
-		   NUM_OF_DIGITAL_PINS };
-
-
-#define NUMBERED_GPIO_DT_SPEC(n, _) \
-	COND_CODE_1(DT_NODE_HAS_PROP(DT_PATH(zephyr_user), d ## n ## _gpios), \
-	      (GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), d ## n ## _gpios),), ())
-
-#define LABELED_GPIO_DT_SPEC(nodeid) GPIO_DT_SPEC_GET_BY_IDX(nodeid, gpios, 0),
-
-static struct gpio_dt_spec arduino_pins[NUM_OF_DIGITAL_PINS] = {
-	LISTIFY(MAX_DIGITAL_PINS, NUMBERED_GPIO_DT_SPEC, ())
-	DT_FOREACH_CHILD(DT_PATH(leds), LABELED_GPIO_DT_SPEC)
+enum digitalPins {
+	DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios, DN_ENUMS, (, )),
+	NUM_OF_DIGITAL_PINS
 };
+
+const struct gpio_dt_spec arduino_pins[] = {DT_FOREACH_PROP_ELEM_SEP(
+	DT_PATH(zephyr_user), digital_pin_gpios, GPIO_DT_SPEC_GET_BY_IDX, (, ))};
 
 #ifdef CONFIG_ADC
 

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -24,6 +24,7 @@
 		 ? 1                                                                               \
 		 : 0)
 
+/* Check all pins are defined only once */
 #define DIGITAL_PIN_CHECK_UNIQUE(i, _)                                                             \
 	((DT_FOREACH_PROP_ELEM_SEP_VARGS(                                                          \
 		 DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS, (+),                 \


### PR DESCRIPTION
The `d0-gpios` node format makes it difficult to handle
digital pin configuration from DTS macros.

Introduce the simple array `digital-pins` instead of `g0-gpios` to define digital pin
to GPIO port and pin mapping.