### PR TITLE
variants: Introduce the builtin-led-gpios node

### DIFF
--- a/documentation/variants.md
+++ b/documentation/variants.md
@@ -129,6 +129,34 @@ The following example instantiates `Wire` and `Wire2` with each `i2c0` and `i2c1
 };
 ```
 
+### Configure Builtin-LED
+
+The `builtin-led-gpios` node defines the Builtin-LED.
+This node defines the `LED_BUILTIN` value by looking up the `digital-pin-gpios`
+array to find the index of the pin.
+
+The node is phandle-array, which uses the format same as `digital-pin-gpios`.
+
+It set the digital pin number to the `LED_BUILTIN` if found the pin
+that defined in `builtin-led-gpios` from `digital-pin-gpios`.
+
+If the `builtin-led-gpios` is not defined, Use the node aliased as `led0`
+to define `LED_BUILTIN`.
+
+The `LED_BUILTIN` does not define here if it has not found both nodes or
+defined `LED_BUILTIN` already.
+
+For example, in the case of the 13th digital pins connected to the onboard LED,
+define `builtin-led-gpios` as follows.
+
+```
+/ {
+	zephyr,user {
+		builtin-led-gpios = <&arduino_nano_header 13 0>;
+	};
+};
+```
+
 ### Overlays from scratch
 
 You can see in the example above that there is no mapping for `LED0` in the

--- a/variants/arduino_mkrzero/arduino_mkrzero.overlay
+++ b/variants/arduino_mkrzero/arduino_mkrzero.overlay
@@ -29,7 +29,8 @@
 				    <&arduino_mkr_header 18 0>, /* D18 / A4 / I2C-SDA */
 				    <&arduino_mkr_header 19 0>, /* D19 / A5 / I2C-SCL */
 				    <&arduino_mkr_header 20 0>,
-				    <&arduino_mkr_header 21 0>;
+				    <&arduino_mkr_header 21 0>,
+				    <&portb 8 0>;
 
 		pwms =	<&tcc0 2 255>,
 			<&tcc0 3 255>;

--- a/variants/arduino_mkrzero/arduino_mkrzero_pinmap.h
+++ b/variants/arduino_mkrzero/arduino_mkrzero_pinmap.h
@@ -9,4 +9,3 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 
-#define LED_BUILTIN 22

--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
@@ -44,6 +44,8 @@
 
 		serials = <&uart0>;
 		i2cs = <&arduino_nano_i2c>;
+
+		builtin-led-gpios = <&arduino_nano_header 13 0>;
 	};
 };
 

--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble_pinmap.h
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble_pinmap.h
@@ -11,4 +11,3 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/device.h>
 
-#define LED_BUILTIN 13

--- a/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense.overlay
+++ b/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense.overlay
@@ -44,6 +44,8 @@
 
 		serials = <&uart0>;
 		i2cs = <&arduino_nano_i2c>;
+
+		builtin-led-gpios = <&arduino_nano_header 13 0>;
 	};
 };
 

--- a/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense_pinmap.h
+++ b/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense_pinmap.h
@@ -11,4 +11,3 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/device.h>
 
-#define LED_BUILTIN 13

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot_pinmap.h
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot_pinmap.h
@@ -11,4 +11,3 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/device.h>
 
-#define LED_BUILTIN 13

--- a/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840_pinmap.h
+++ b/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840_pinmap.h
@@ -11,6 +11,4 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 
-#define LED_BUILTIN 22
-
 #endif


### PR DESCRIPTION
Introduce the `builtin-led-gpios` node to make possible to configuring
the builtin-led from dts.
This node uses to determine the value of the `LED_BUILTIN` macro.

Use the `led0` alias to determine the `LED_BUILTIN` if the `builtin-led-gpios`
is not defined.

The behavior can override by defining the `LED_BUILTIN` in pinmap.h.
It uses definitions that are defined in the header preferentially.

---

The PR is contineued from #60.
I will rebase if #60 merged.