### PR TITLE
variants: arduino_nano_33_iot: describe unit address in hex

### DIFF
--- a/variants/arduino_mkrzero/arduino_mkrzero.overlay
+++ b/variants/arduino_mkrzero/arduino_mkrzero.overlay
@@ -86,7 +86,7 @@
 	#size-cells = <0>;
 
 	channel@0 {
-		reg = <0>;
+		reg = <0x0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -95,7 +95,7 @@
 	};
 
 	channel@4 {
-		reg = <4>;
+		reg = <0x4>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -104,7 +104,7 @@
 	};
 
 	channel@5 {
-		reg = <5>;
+		reg = <0x5>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -113,7 +113,7 @@
 	};
 
 	channel@6 {
-		reg = <6>;
+		reg = <0x6>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -122,7 +122,7 @@
 	};
 
 	channel@7 {
-		reg = <7>;
+		reg = <0x7>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -130,8 +130,8 @@
 		zephyr,input-positive = <7>;
 	};
 
-	channel@10 {
-		reg = <10>;
+	channel@a {
+		reg = <0xa>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -139,8 +139,8 @@
 		zephyr,input-positive = <10>;
 	};
 
-	channel@11 {
-		reg = <11>;
+	channel@b {
+		reg = <0xb>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
@@ -93,7 +93,7 @@
 	#size-cells = <0>;
 
 	channel@0 {
-		reg = <0>;
+		reg = <0x0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -102,7 +102,7 @@
 	};
 
 	channel@2 {
-		reg = <2>;
+		reg = <0x2>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -111,7 +111,7 @@
 	};
 
 	channel@3 {
-		reg = <3>;
+		reg = <0x3>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -119,8 +119,8 @@
 		zephyr,input-positive = <3>;
 	};
 
-	channel@10 {
-		reg = <10>;
+	channel@a {
+		reg = <0xa>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -128,8 +128,8 @@
 		zephyr,input-positive = <10>;
 	};
 
-	channel@11 {
-		reg = <11>;
+	channel@b {
+		reg = <0xb>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -137,8 +137,8 @@
 		zephyr,input-positive = <11>;
 	};
 
-	channel@18 {
-		reg = <18>;
+	channel@12 {
+		reg = <0x12>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
@@ -146,8 +146,8 @@
 		zephyr,input-positive = <18>;
 	};
 
-	channel@19 {
-		reg = <19>;
+	channel@13 {
+		reg = <0x13>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;


### PR DESCRIPTION
Fix this warnings

```
unit address and first address in 'reg' (0xa) don't match for /soc/adc@42004000/channel@10
unit address and first address in 'reg' (0xb) don't match for /soc/adc@42004000/channel@11
unit address and first address in 'reg' (0x12) don't match for /soc/adc@42004000/channel@18
unit address and first address in 'reg' (0x13) don't match for /soc/adc@42004000/channel@19
```

```
unit address and first address in 'reg' (0x6a) don't match for /soc/sercom@42001800/atecc608a@15
```
may be problem in `boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts`
