### PR TITLE
GPIO cells use to PWM and ADC pin assigning

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -113,14 +113,17 @@ void handleGpioCallback(const struct device *port, struct gpio_callback *cb, uin
 #ifdef CONFIG_PWM
 
 #define PWM_DT_SPEC(n,p,i) PWM_DT_SPEC_GET_BY_IDX(n, i),
-#define PWM_PINS(n,p,i) DT_PROP_BY_IDX(n, p, i),
+#define PWM_PINS(n, p, i) \
+	DIGITAL_PIN_GPIOS_FIND_PIN( \
+                DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),        \
+                DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
 
 const struct pwm_dt_spec arduino_pwm[] =
 	{ DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwms, PWM_DT_SPEC) };
 
 /* pwm-pins node provides a mapping digital pin numbers to pwm channels */
 const pin_size_t arduino_pwm_pins[] =
-	{ DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwm_pins, PWM_PINS) };
+	{ DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwm_pin_gpios, PWM_PINS) };
 
 size_t pwm_pin_index(pin_size_t pinNumber) {
   for(size_t i=0; i<ARRAY_SIZE(arduino_pwm_pins); i++) {
@@ -136,7 +139,10 @@ size_t pwm_pin_index(pin_size_t pinNumber) {
 #ifdef CONFIG_ADC
 
 #define ADC_DT_SPEC(n,p,i) ADC_DT_SPEC_GET_BY_IDX(n, i),
-#define ADC_PINS(n,p,i) DT_PROP_BY_IDX(n, p, i),
+#define ADC_PINS(n, p, i) \
+	DIGITAL_PIN_GPIOS_FIND_PIN( \
+                DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),        \
+                DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
 #define ADC_CH_CFG(n,p,i) arduino_adc[i].channel_cfg,
 
 const struct adc_dt_spec arduino_adc[] =
@@ -144,7 +150,7 @@ const struct adc_dt_spec arduino_adc[] =
 
 /* io-channel-pins node provides a mapping digital pin numbers to adc channels */
 const pin_size_t arduino_analog_pins[] =
-  { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channel_pins, ADC_PINS) };
+  { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), adc_pin_gpios, ADC_PINS) };
 
 struct adc_channel_cfg channel_cfg[ARRAY_SIZE(arduino_analog_pins)] =
   { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_CH_CFG) };

--- a/documentation/variants.md
+++ b/documentation/variants.md
@@ -49,10 +49,15 @@ variants/
 
 ### DeviceTree Overlay files for Arduino boards
 
-This module requires that your Arduino header pins be mapped in the DeviceTree
-to 'digital-pin-gpios' array that child of a `zephyr,user` node. Follow the
-examples in the variants directory to create an overlay file and a header file
-for your board.
+The Arduino API requires pin mapping definitions to use Arduino-style pin numbers
+(pin numbers printed on the board, not GPIO numbers).
+The pin-mapping node is under the `zephyr,user` node of DTS.
+`digital-pin-gpios` defines digital input/output pins that is D0, D1, ..,
+`adc-pin-gpios` defines analog input pins that is A0, A1, ... .
+`pwm-pin-gpios` defines PWM pins.
+Each pin specifies in the form of a GPIO cell.
+Usually, it is in the form of `<[port] [pin-number] [flag]>`.
+You can also use the Arduino header node definition here.
 
 ### Overlays using previously-defined Arduino headers
 

--- a/variants/arduino_mkrzero/arduino_mkrzero.overlay
+++ b/variants/arduino_mkrzero/arduino_mkrzero.overlay
@@ -32,9 +32,19 @@
 				    <&arduino_mkr_header 21 0>,
 				    <&portb 8 0>;
 
+		pwm-pin-gpios =     <&arduino_mkr_header 2 0>,
+				    <&arduino_mkr_header 3 0>;
+
+		adc-pin-gpios =	    <&arduino_mkr_header 15 0>,
+				    <&arduino_mkr_header 16 0>,
+				    <&arduino_mkr_header 17 0>,
+				    <&arduino_mkr_header 18 0>,
+				    <&arduino_mkr_header 19 0>,
+				    <&arduino_mkr_header 20 0>,
+				    <&arduino_mkr_header 21 0>;
+
 		pwms =	<&tcc0 2 255>,
 			<&tcc0 3 255>;
-		pwm-pins = <2 3>;
 
 		io-channels =	<&adc 0>,
 				<&adc 10>,
@@ -43,7 +53,6 @@
 				<&adc 5>,
 				<&adc 6>,
 				<&adc 7>;
-		io-channel-pins = <15 16 17 18 19 20 21>;
 
 		serials = <&sercom5>;
 		i2cs = <&sercom0>;

--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
@@ -23,6 +23,25 @@
 				    <&arduino_nano_header 20 0>,
 				    <&arduino_nano_header 21 0>;
 
+		pwm-pin-gpios =	    <&arduino_nano_header 3 0>,
+				    <&arduino_nano_header 5 0>,
+				    <&arduino_nano_header 6 0>,
+				    <&arduino_nano_header 13 0>,
+				    <&arduino_nano_header 9 0>,
+				    <&arduino_nano_header 10 0>,
+				    <&arduino_nano_header 11 0>;
+
+		adc-pin-gpios =	    <&arduino_nano_header 14 0>,
+				    <&arduino_nano_header 15 0>,
+				    <&arduino_nano_header 16 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 18 0>,
+				    <&arduino_nano_header 19 0>,
+				    <&arduino_nano_header 20 0>,
+				    <&arduino_nano_header 21 0>;
+
+		builtin-led-gpios = <&arduino_nano_header 13 0>;
+
 		pwms =	<&pwm1 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 2 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 3 255 PWM_POLARITY_NORMAL>,
@@ -30,7 +49,6 @@
 			<&pwm2 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm2 2 255 PWM_POLARITY_NORMAL>,
 			<&pwm2 3 255 PWM_POLARITY_NORMAL>;
-		pwm-pins = <3 5 6 13 9 10 11>;
 
 		io-channels =	<&adc 2>,
 				<&adc 3>,
@@ -40,12 +58,9 @@
 				<&adc 0>,
 				<&adc 4>,
 				<&adc 1>;
-		io-channel-pins = <14 15 16 17 18 19 20 21>;
 
 		serials = <&uart0>;
 		i2cs = <&arduino_nano_i2c>;
-
-		builtin-led-gpios = <&arduino_nano_header 13 0>;
 	};
 };
 

--- a/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense.overlay
+++ b/variants/arduino_nano_33_ble_sense/arduino_nano_33_ble_sense.overlay
@@ -23,6 +23,25 @@
 				    <&arduino_nano_header 20 0>,
 				    <&arduino_nano_header 21 0>;
 
+		pwm-pin-gpios =	    <&arduino_nano_header 3 0>,
+				    <&arduino_nano_header 5 0>,
+				    <&arduino_nano_header 6 0>,
+				    <&arduino_nano_header 13 0>,
+				    <&arduino_nano_header 9 0>,
+				    <&arduino_nano_header 10 0>,
+				    <&arduino_nano_header 11 0>;
+
+		adc-pin-gpios =	    <&arduino_nano_header 14 0>,
+				    <&arduino_nano_header 15 0>,
+				    <&arduino_nano_header 16 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 18 0>,
+				    <&arduino_nano_header 19 0>,
+				    <&arduino_nano_header 20 0>,
+				    <&arduino_nano_header 21 0>;
+
+		builtin-led-gpios = <&arduino_nano_header 13 0>;
+
 		pwms =	<&pwm1 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 2 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 3 255 PWM_POLARITY_NORMAL>,
@@ -30,7 +49,6 @@
 			<&pwm2 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm2 2 255 PWM_POLARITY_NORMAL>,
 			<&pwm2 3 255 PWM_POLARITY_NORMAL>;
-		pwm-pins = <3 5 6 13 9 10 11>;
 
 		io-channels =	<&adc 2>,
 				<&adc 3>,
@@ -40,12 +58,9 @@
 				<&adc 0>,
 				<&adc 4>,
 				<&adc 1>;
-		io-channel-pins = <14 15 16 17 18 19 20 21>;
 
 		serials = <&uart0>;
 		i2cs = <&arduino_nano_i2c>;
-
-		builtin-led-gpios = <&arduino_nano_header 13 0>;
 	};
 };
 

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
@@ -25,6 +25,24 @@
 				    <&arduino_nano_header 20 0>,
 				    <&arduino_nano_header 21 0>;
 
+		pwm-pin-gpios =	    <&arduino_nano_header 6 0>,
+				    <&arduino_nano_header 5 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 12 0>,
+				    <&arduino_nano_header 2 0>,
+				    <&arduino_nano_header 3 0>,
+				    <&arduino_nano_header 9 0>,
+				    <&arduino_nano_header 10 0>;
+
+		adc-pin-gpios =     <&arduino_nano_header 14 0>,
+				    <&arduino_nano_header 15 0>,
+				    <&arduino_nano_header 16 0>,
+				    <&arduino_nano_header 17 0>,
+				    <&arduino_nano_header 18 0>,
+				    <&arduino_nano_header 19 0>,
+				    <&arduino_nano_header 20 0>,
+				    <&arduino_nano_header 21 0>;
+
 		pwms =	<&tcc0 0 255>,
 			<&tcc0 1 255>,
 			<&tcc0 2 255>,
@@ -33,7 +51,6 @@
 			<&tcc0 5 255>,
 			<&tcc0 6 255>,
 			<&tcc0 7 255>;
-		pwm-pins = <6 5 17 12 2 3 9 10>;
 
 		io-channels =	<&adc 0>,
 				<&adc 10>,
@@ -42,7 +59,6 @@
 				<&adc 5>,
 				<&adc 6>,
 				<&adc 7>;
-		io-channel-pins = <14 15 16 17 18 19 20 21>;
 
 		serials = <&sercom5>;
 		i2cs = <&arduino_nano_i2c>;

--- a/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
+++ b/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
@@ -24,13 +24,27 @@
 				    <&arduino_header 5 0>,
 				    <&gpio0 13 GPIO_ACTIVE_LOW>;
 
+		pwm-pin-gpios =     <&gpio0 13 GPIO_ACTIVE_LOW>,
+				    <&arduino_header 9 0>,
+				    <&arduino_header 11 0>,
+				    <&arduino_header 12 0>,
+				    <&arduino_header 15 0>,
+				    <&arduino_header 16 0>,
+				    <&arduino_header 17 0>;
+
+		adc-pin-gpios =	    <&arduino_header 0 0>,
+				    <&arduino_header 1 0>,
+				    <&arduino_header 2 0>,
+				    <&arduino_header 3 0>,
+				    <&arduino_header 4 0>,
+				    <&arduino_header 5 0>;
+
 		pwms =	<&pwm0 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm0 2 255 PWM_POLARITY_NORMAL>,
 			<&pwm0 3 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 0 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 1 255 PWM_POLARITY_NORMAL>,
 			<&pwm1 2 255 PWM_POLARITY_NORMAL>;
-		pwm-pins = <22 3 5 6 9 10 11>;
 
 		io-channels =	<&arduino_adc 0>,
 				<&arduino_adc 1>,
@@ -38,7 +52,6 @@
 				<&arduino_adc 3>,
 				<&arduino_adc 4>,
 				<&arduino_adc 5>;
-		io-channel-pins = <16 17 18 19 20 21>;
 	};
 };
 

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -44,7 +44,7 @@
 	(DIGITAL_PIN_EXISTS(n, p, i, dev, num) ? i : 0)
 
 /* Only matched pin returns non-zero value, so the sum is matched pin's index */
-#define LED_BUILTIN_FIND_DIGITAL_PIN(dev, pin)                                                     \
+#define DIGITAL_PIN_GPIOS_FIND_PIN(dev, pin)                                                     \
 	DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(zephyr_user), digital_pin_gpios,                    \
 				       LED_BUILTIN_INDEX_BY_REG_AND_PINNUM, (+), dev, pin)
 
@@ -58,7 +58,7 @@
 #warning "pin not found in digital_pin_gpios"
 #else
 #define LED_BUILTIN                                                                                \
-	LED_BUILTIN_FIND_DIGITAL_PIN(                                                              \
+	DIGITAL_PIN_GPIOS_FIND_PIN(                                                              \
 		DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0)),        \
 		DT_PHA_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0, pin))
 #endif
@@ -72,7 +72,7 @@
 #warning "pin not found in digital_pin_gpios"
 #else
 #define LED_BUILTIN                                                                                \
-	LED_BUILTIN_FIND_DIGITAL_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_ALIAS(led0), gpios, 0)),     \
+	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_ALIAS(led0), gpios, 0)),     \
 				     DT_PHA_BY_IDX(DT_ALIAS(led0), gpios, 0, pin))
 #endif
 

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -96,8 +96,10 @@ const struct gpio_dt_spec arduino_pins[] = {DT_FOREACH_PROP_ELEM_SEP(
 
 #ifdef CONFIG_ADC
 
-#define AN_ENUMS(n, p, i) A ## i = DT_PROP_BY_IDX(n, p, i),
+#define AN_ENUMS(n, p, i) A ## i = DIGITAL_PIN_GPIOS_FIND_PIN( \
+		DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),        \
+		DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
 enum analogPins { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user),
-				       io_channel_pins, AN_ENUMS) };
+				       adc_pin_gpios, AN_ENUMS) };
 
 #endif


### PR DESCRIPTION
Change to use GPIO cells to assign PWM and ADC pins.
This change makes it easier to manage because unifying
the notation with `digital-pin-gpios`.
Deleting `pwm-pins` and `io-channel-pins` nodes, and create
`pwm-pin-gpios` and `adc-pins-gpios`.