### PR TITLE
CI/CD: setup docker image build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: zephyrprojectrtos/ci:latest
+    env:
+      CMAKE_PREFIX_PATH: /opt/toolchains
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: Arduino-Zephyr-API
+
+      - name: Initialize
+        working-directory: Arduino-Zephyr-API
+        run: |
+          west init -m https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core.git
+          west update
+          git clone https://github.com/arduino/ArduinoCore-API.git ArduinoCore-API
+          sed '/WCharacter.h/ s/./\/\/ &/' ArduinoCore-API/api/ArduinoAPI.h > ArduinoCore-API/api/tmpArduinoAPI.h
+          mv ArduinoCore-API/api/tmpArduinoAPI.h ArduinoCore-API/api/ArduinoAPI.h
+          cp -r ArduinoCore-API/api modules/lib/Arduino-Zephyr-API/cores/arduino/.
+
+      - name: Build fade
+        working-directory: Arduino-Zephyr-API
+        run: |
+          west build -p -b arduino_nano_33_ble_sense samples/fade
+
+      - name: Build i2cdemo
+        working-directory: Arduino-Zephyr-API
+        run: |
+          west build -p -b arduino_nano_33_ble_sense samples/i2cdemo
+
+      - name: Archive firmware
+        uses: actions/upload-artifact@v2
+        with:
+          name: firmware
+          path: Arduino-Zephyr-API/build/zephyr/zephyr.*


### PR DESCRIPTION
Creates a CI CD workflow to build the next branch for every push  / pull request.
This will ensure that the next branch always builds and is in a build-able state. Thus just before merging into main we will have public record of the module being built.