### PR TITLE
create west.yml

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2022 Dhruva Gole <goledhruva@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This is created to be used for CI/CD workflow. So use it only
+# if you are in the zephyrproject directory or else things may break.
+
+manifest:
+  self:
+    path: modules/lib/Arduino-Zephyr-API
+
+  remotes:
+    - name: zephyrproject-rtos
+      url-base: https://github.com/zephyrproject-rtos
+
+  projects:
+    - name: zephyr
+      remote: zephyrproject-rtos
+      revision: main
+      import: true


### PR DESCRIPTION
This file can be used to directly pull and use this module. Main use case at the moment is to easily pull this module in a docker container and then run a simple sample build test to see if code compiles without errors.

Furthermore this PR also contains a Dockerfile that can be  used locally as well as in CI/CD workflows.

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>