### PR TITLE
variants: Add cc3220sf

### DIFF
--- a/variants/cc3220sf_launchxl/cc3220sf_launchxl.overlay
+++ b/variants/cc3220sf_launchxl/cc3220sf_launchxl.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Dhruva Gole <goledhruva@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ / {
+	zephyr,user {
+		digital-pin-gpios = <&boosterpack_header 4 0>,	/* GPIO_12 */
+				<&boosterpack_header 5 0>,	/* GPIO_06 */
+				<&boosterpack_header 7 0>,	/* GPIO_14 */
+				<&boosterpack_header 9 0>,	/* I2C_SCL | YELLOW_LED */
+				<&boosterpack_header 10 0>,	/* I2C_SDA | GREEN_LED  */
+				<&boosterpack_header 11 0>,	/* GPIO_22 */
+				<&boosterpack_header 12 0>,	/* GPIO_01 */
+				<&boosterpack_header 13 0>,	/* GPIO_25 */
+				<&boosterpack_header 14 0>,	/* GPIO_15 */
+				<&boosterpack_header 15 0>,	/* GPIO_16 */
+				<&boosterpack_header 17 0>,	/* GPIO_31 */
+				<&boosterpack_header 18 0>,	/* GPIO_17 */
+				<&boosterpack_header 19 0>,	/* GPIO_28 */
+				<&boosterpack_header 23 0>,	/* GPIO_02 | AIN0 */
+				<&boosterpack_header 24 0>,	/* GPIO_05 | AIN3 */
+				<&boosterpack_header 25 0>,	/* GPIO_03 | AIN1 */
+				<&boosterpack_header 26 0>,	/* GPIO_04 | AIN2 */
+				<&boosterpack_header 27 0>,	/* GPIO_08 */
+				<&boosterpack_header 28 0>,	/* GPIO_30 */
+				<&boosterpack_header 29 0>,	/* GPIO_09 | RED_LED | I2S_DOUT*/
+				<&boosterpack_header 30 0>,	/* GPIO_00 */
+				<&boosterpack_header 31 0>,	/* GPIO_24 */
+				<&boosterpack_header 32 0>;	/* GPIO_23 */
+		builtin-led-gpios = <&boosterpack_header 10 0>;	/*  GREEN_LED  */
+		serials = <&boosterpack_serial>;
+		i2cs = <&boosterpack_i2c>;
+	};
+ };

--- a/variants/cc3220sf_launchxl/cc3220sf_launchxl_pinmap.h
+++ b/variants/cc3220sf_launchxl/cc3220sf_launchxl_pinmap.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0 */
+#pragma once
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/device.h>
+
+#define LED_BUILTIN 4
+#define YELLOW_LED 3
+#define GREEN_LED 4
+#define RED_LED 19
+

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -17,6 +17,9 @@
 #ifdef CONFIG_BOARD_ARDUINO_MKRZERO
 #include "arduino_mkrzero_pinmap.h"
 #endif // CONFIG_BOARD_ARDUINO_MKRZERO
+#ifdef CONFIG_BOARD_CC3220SF_LAUNCHXL
+#include "cc3220sf_launchxl_pinmap.h"
+#endif // CONFIG_BOARD_CC3220SF_LAUNCHXL
 
 #define DIGITAL_PIN_EXISTS(n, p, i, dev, num)                                                      \
 	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) &&                                      \


### PR DESCRIPTION
Add support for the TI [CC3220SF LaunchXL](https://www.ti.com/product/CC3200#software-development) platform

Closes https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core/issues/35