### PR TITLE
Request to pull in changes for Aug 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# GSoC 2022 Project
+# GSoC 2022 Project: Arduino Core API module for Zephyr
 
 ![](https://dhruvag2000.github.io/Blog-GSoC22/assets/images/website_header.png)
 
-## Arduino Core API module for zephyr
-
-Arduino Core API module for zephyr leverages the power of Zephyr under an Arduino-C++ style abtraction layer thus helping zephyr new-comers to start using it without worrying about learning about new APIs and libraries. See the project documentation folder for detailed documentation on these topics:
+The **Arduino Core API** module for zephyr leverages the power of Zephyr under an Arduino-C++ style abtraction layer thus helping zephyr new-comers to start using it without worrying about learning about new APIs and libraries. See the project documentation folder for detailed documentation on these topics:
 
 * [Using external Arduino Libraries](/documentation/arduino_libs.md)
 * [Adding custom boards/ variants](/documentation/variants.md)
@@ -45,11 +43,11 @@ __NOTE:__ You can skip this step as well if you ran ``install.sh``.
 * While compiling with the ArduinoCore-API `WCharacter.h` produces many errors. The include of that file needs to be deleted from `cores/arduino/api/ArduinoAPI.h` (it is unused in this port.) We are looking into resolving the issue.
 
 **Maintainers**:
+- [DhruvaG2000](https://github.com/DhruvaG2000)
+- [soburi](https://github.com/soburi)
 - [szczys](https://github.com/szczys)
-- [beriberikix](https://github.com/beriberikix) 
+- [beriberikix](https://github.com/beriberikix)
 - [alvarowolfx](https://github.com/alvarowolfx)
-
-**Contributor**: [DhruvaG2000](https://github.com/DhruvaG2000)
 
 ## License
 Please note that the current license is Apache 2. Previously it was LGPL 2.1 but after careful review it was determined that no LGPL code or derivates was used and the more permissive license was chosen.

--- a/samples/analog_input/CMakeLists.txt
+++ b/samples/analog_input/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(analog_input)

--- a/samples/attach_interrupt/CMakeLists.txt
+++ b/samples/attach_interrupt/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(attach_interrupt)

--- a/samples/blinky_arduino/CMakeLists.txt
+++ b/samples/blinky_arduino/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)

--- a/samples/button_press_led/CMakeLists.txt
+++ b/samples/button_press_led/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)

--- a/samples/fade/CMakeLists.txt
+++ b/samples/fade/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fade)

--- a/samples/hello_arduino/CMakeLists.txt
+++ b/samples/hello_arduino/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hello_world)

--- a/samples/i2cdemo/CMakeLists.txt
+++ b/samples/i2cdemo/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)

--- a/samples/serial_event/CMakeLists.txt
+++ b/samples/serial_event/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(serial_event)

--- a/samples/threads_arduino/CMakeLists.txt
+++ b/samples/threads_arduino/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(DTC_OVERLAY_FILE $ENV{ZEPHYR_BASE}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
+cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
+set(DTC_OVERLAY_FILE ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API/variants/${BOARD}/${BOARD}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(threads)

--- a/variants/cc3220sf_launchxl/cc3220sf_launchxl.overlay
+++ b/variants/cc3220sf_launchxl/cc3220sf_launchxl.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Dhruva Gole <goledhruva@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ / {
+	zephyr,user {
+		digital-pin-gpios = <&boosterpack_header 4 0>,	/* GPIO_12 */
+				<&boosterpack_header 5 0>,	/* GPIO_06 */
+				<&boosterpack_header 7 0>,	/* GPIO_14 */
+				<&boosterpack_header 9 0>,	/* I2C_SCL | YELLOW_LED */
+				<&boosterpack_header 10 0>,	/* I2C_SDA | GREEN_LED  */
+				<&boosterpack_header 11 0>,	/* GPIO_22 */
+				<&boosterpack_header 12 0>,	/* GPIO_01 */
+				<&boosterpack_header 13 0>,	/* GPIO_25 */
+				<&boosterpack_header 14 0>,	/* GPIO_15 */
+				<&boosterpack_header 15 0>,	/* GPIO_16 */
+				<&boosterpack_header 17 0>,	/* GPIO_31 */
+				<&boosterpack_header 18 0>,	/* GPIO_17 */
+				<&boosterpack_header 19 0>,	/* GPIO_28 */
+				<&boosterpack_header 23 0>,	/* GPIO_02 | AIN0 */
+				<&boosterpack_header 24 0>,	/* GPIO_05 | AIN3 */
+				<&boosterpack_header 25 0>,	/* GPIO_03 | AIN1 */
+				<&boosterpack_header 26 0>,	/* GPIO_04 | AIN2 */
+				<&boosterpack_header 27 0>,	/* GPIO_08 */
+				<&boosterpack_header 28 0>,	/* GPIO_30 */
+				<&boosterpack_header 29 0>,	/* GPIO_09 | RED_LED | I2S_DOUT*/
+				<&boosterpack_header 30 0>,	/* GPIO_00 */
+				<&boosterpack_header 31 0>,	/* GPIO_24 */
+				<&boosterpack_header 32 0>;	/* GPIO_23 */
+		builtin-led-gpios = <&boosterpack_header 10 0>;	/*  GREEN_LED  */
+		serials = <&boosterpack_serial>;
+		i2cs = <&boosterpack_i2c>;
+	};
+ };

--- a/variants/cc3220sf_launchxl/cc3220sf_launchxl_pinmap.h
+++ b/variants/cc3220sf_launchxl/cc3220sf_launchxl_pinmap.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* All the pins that are 100 + x are gpio1 pins and < 100 are in gpio0 */
+#pragma once
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/device.h>
+
+#define LED_BUILTIN 4
+#define YELLOW_LED 3
+#define GREEN_LED 4
+#define RED_LED 19
+

--- a/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.overlay
+++ b/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,192 @@
+/ {
+	zephyr,user {
+		digital-pin-gpios = 
+			<&arduino_header 6 0>,	/* Digital */
+			<&arduino_header 7 0>,
+			<&arduino_header 8 0>,
+			<&arduino_header 9 0>,
+			<&arduino_header 10 0>,
+			<&arduino_header 11 0>,
+			<&arduino_header 12 0>,
+			<&arduino_header 13 0>,
+			<&arduino_header 14 0>,
+			<&arduino_header 15 0>,
+			<&arduino_header 16 0>,
+			<&arduino_header 17 0>,
+			<&arduino_header 18 0>,
+			<&arduino_header 19 0>,
+			<&arduino_header 20 0>,
+			<&arduino_header 21 0>,
+			<&arduino_header 0 0>,	/* Analog */
+			<&arduino_header 1 0>,
+			<&arduino_header 2 0>,
+			<&arduino_header 3 0>,
+			<&arduino_header 4 0>,
+			<&arduino_header 5 0>,
+			<&gpio0 13 GPIO_ACTIVE_LOW>;
+
+		pwm-pin-gpios =     
+			<&gpio0 13 GPIO_ACTIVE_LOW>,
+			<&arduino_header 9 0>,
+			<&arduino_header 11 0>,
+			<&arduino_header 12 0>,
+			<&arduino_header 15 0>,
+			<&arduino_header 16 0>,
+			<&arduino_header 17 0>;
+
+		adc-pin-gpios =	    
+			<&arduino_header 0 0>,
+			<&arduino_header 1 0>,
+			<&arduino_header 2 0>,
+			<&arduino_header 3 0>,
+			<&arduino_header 4 0>,
+			<&arduino_header 5 0>;
+
+		pwms =	
+			<&pwm0 1 255 PWM_POLARITY_NORMAL>,
+			<&pwm0 2 255 PWM_POLARITY_NORMAL>,
+			<&pwm0 3 255 PWM_POLARITY_NORMAL>,
+			<&pwm1 0 255 PWM_POLARITY_NORMAL>,
+			<&pwm1 1 255 PWM_POLARITY_NORMAL>,
+			<&pwm1 2 255 PWM_POLARITY_NORMAL>;
+
+		io-channels =	
+			<&arduino_adc 0>,
+			<&arduino_adc 1>,
+			<&arduino_adc 2>,
+			<&arduino_adc 3>,
+			<&arduino_adc 4>,
+			<&arduino_adc 5>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN0>; /* P0.02 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN1>; /* P0.03 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P0.04 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN3>; /* P0.05 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>; /* P0.28 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN5>; /* P0.29 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P0.30 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN7>; /* P0.31 */
+		zephyr,resolution = <10>;
+	};
+};
+
+&pinctrl {
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>, /* keep original config */
+				<NRF_PSEL(PWM_OUT1, 1, 4)>,
+				<NRF_PSEL(PWM_OUT2, 1, 6)>,
+				<NRF_PSEL(PWM_OUT3, 1, 7)>;
+				nordic,invert;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>, /* keep original config */
+				<NRF_PSEL(PWM_OUT1, 1, 4)>,
+				<NRF_PSEL(PWM_OUT2, 1, 6)>,
+				<NRF_PSEL(PWM_OUT3, 1, 7)>;
+				low-power-enable;
+		};
+	};
+
+	pwm1_default: pwm1_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 11)>,
+				<NRF_PSEL(PWM_OUT1, 1, 12)>,
+				<NRF_PSEL(PWM_OUT2, 1, 13)>;
+				nordic,invert;
+		};
+	};
+
+	pwm1_sleep: pwm1_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 11)>,
+				<NRF_PSEL(PWM_OUT1, 1, 12)>,
+				<NRF_PSEL(PWM_OUT2, 1, 13)>;
+				low-power-enable;
+		};
+	};
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm1 {
+	status = "okay";
+	pinctrl-0 = <&pwm1_default>;
+	pinctrl-1 = <&pwm1_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160_pinmap.h
+++ b/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160_pinmap.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Dejan Deletic
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INCLUDE_NRF1960DK_NRF1960_PINMAP_H
+#define INCLUDE_NRF1960DK_NRF1960_PINMAP_H
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
+
+#define NRF9160DK_LED_1         D2          // P0.02
+#define NRF9160DK_LED_2         D3          // P0.03
+#define NRF9160DK_LED_3         D4          // P0.04
+#define NRF9160DK_LED_4         D5          // P0.05
+
+#define NRF9160DK_SWITCH_1      D6          // P0.08
+#define NRF9160DK_SWITCH_2      D7          // P0.09
+#define NRF9160DK_BUTTON_1      D8          // P0.06
+#define NRF9160DK_BUTTON_2      D9          // P0.07
+
+#endif

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -17,6 +17,9 @@
 #ifdef CONFIG_BOARD_ARDUINO_MKRZERO
 #include "arduino_mkrzero_pinmap.h"
 #endif // CONFIG_BOARD_ARDUINO_MKRZERO
+#ifdef CONFIG_BOARD_CC3220SF_LAUNCHXL
+#include "cc3220sf_launchxl_pinmap.h"
+#endif // CONFIG_BOARD_CC3220SF_LAUNCHXL
 
 #define DIGITAL_PIN_EXISTS(n, p, i, dev, num)                                                      \
 	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) &&                                      \

--- a/variants/variants.h
+++ b/variants/variants.h
@@ -14,6 +14,9 @@
 #ifdef CONFIG_BOARD_NRF52840DK_NRF52840
 #include "nrf52840dk_nrf52840_pinmap.h"
 #endif /* CONFIG_BOARD_NRF52840DK_NRF52840 */
+#ifdef CONFIG_BOARD_NRF9160DK_NRF9160
+#include "nrf9160dk_nrf9160_pinmap.h"
+#endif /* CONFIG_BOARD_NRF9160DK_NRF9160 */
 #ifdef CONFIG_BOARD_ARDUINO_MKRZERO
 #include "arduino_mkrzero_pinmap.h"
 #endif // CONFIG_BOARD_ARDUINO_MKRZERO


### PR DESCRIPTION
A lot of new additions this time,

* Adds support for TI-CC3220SF LaunchXL
*  [Add support for nRF9160](https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core/commit/976925a6074b2eca7942f9f03742624acd9a274e)
* [samples: Fix paths to overlay files given to cmake on Windows](https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core/commit/bcfd8baaa1eae7f919f6cb81b6e6c2ba9f16b6b7)