### PR TITLE
zephyrSerial: Fix misdetection arduino_serial1

### DIFF
--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -186,7 +186,7 @@ arduino::ZephyrSerial Serial(DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user
 
 DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_SERIAL_N)
 #endif // PROP_LEN(serials) > 1
-#elif DT_NODE_EXISTS(DT_NODELABEL(arduino_serial))
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(arduino_serial), okay)
 /* If serials node is not defined, tries to use arduino_serial */
 arduino::ZephyrSerial Serial(DEVICE_DT_GET(DT_NODELABEL(arduino_serial)));
 #else

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -92,7 +92,7 @@ DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_EXTERN_SERIAL_N)
 #undef EXTERN_SERIAL_N
 #undef SERIAL_DEFINED_0
 #endif
-#elif DT_NODE_EXISTS(DT_NODELABEL(arduino_serial))
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(arduino_serial), okay)
 extern arduino::ZephyrSerial Serial;
 #else
 extern arduino::ZephyrSerialStub Serial;


### PR DESCRIPTION
There was an issue that caused build failures for `nrf52840dk_nrf52840` which is what this PR aimed to fix.

With this merged into main I think all variants build successfully and we should be good to tag it as the next release.