### PR TITLE
Add ARDUINO_ENTRY config variable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -26,4 +26,8 @@ config ARDUINO_API_SERIAL_BUFFER_SIZE
 	int "Buffer size for Arduino Serial API"
 	default 64
 
+config ARDUINO_ENTRY
+	bool "Provide arduino setup and loop entry points"
+	default y
+
 endif

--- a/cores/arduino/CMakeLists.txt
+++ b/cores/arduino/CMakeLists.txt
@@ -7,7 +7,10 @@ if(NOT DEFINED ARDUINO_BUILD_PATH)
 zephyr_sources(zephyrPrint.cpp)
 zephyr_sources(zephyrSerial.cpp)
 zephyr_sources(zephyrCommon.cpp)
+
+if(DEFINED CONFIG_ARDUINO_ENTRY)
 zephyr_sources(main.cpp)
+endif()
 
 endif()
 


### PR DESCRIPTION
- Controls if arduino entry functions (setup and loop) wrapper is provided
- Useful for porting programs since while it might need Arduino APIs, but don't really need setup and loop structure.
- Also useful for slowly migrating to Zephyr APIs