### PR TITLE
beagleconnect_freedom: Fix pwm1

### DIFF
--- a/variants/beagleconnect_freedom/beagleconnect_freedom.overlay
+++ b/variants/beagleconnect_freedom/beagleconnect_freedom.overlay
@@ -62,7 +62,7 @@
 	};
 
 	pwm1_default: pwm1_default {
-		pinmux = <19 IOC_PORT_MCU_PORT_EVENT1>;
+		pinmux = <19 IOC_PORT_MCU_PORT_EVENT3>;
 		bias-disable;
 		drive-strength = <2>;
 	};


### PR DESCRIPTION
- Fix the incorrect event in pwm1 pin
- Once https://github.com/zephyrproject-rtos/zephyr/pull/75198 is merged, PWM should work fine with bcf too.