### PR TITLE
Installation: delete step to comment out WCharacter from ArduinoCore API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ The `cores` folder can be found at `~/zephyrproject/modules/lib/Arduino-Zephyr-A
 
 __NOTE:__ You can skip this step as well if you ran ``install.sh``.
 
-* While compiling with the ArduinoCore-API `WCharacter.h` produces many errors. The include of that file needs to be deleted from `cores/arduino/api/ArduinoAPI.h` (it is unused in this port.) We are looking into resolving the issue.
-
 **Maintainers**:
 - [DhruvaG2000](https://github.com/DhruvaG2000)
 - [soburi](https://github.com/soburi)

--- a/install.sh
+++ b/install.sh
@@ -22,10 +22,6 @@ else
 	printf '%s\n' "API Folder already exists, skipping clone...";
 fi
 
-printf '%s\n' "Commenting out WCharacter.h because it fails to build properly";
-sed '/WCharacter.h/ s/./\/\/ &/' ~/.ArduinoCore-API/api/ArduinoAPI.h > ~/.ArduinoCore-API/api/tmpArduinoAPI.h ;
-mv ~/.ArduinoCore-API/api/tmpArduinoAPI.h ~/.ArduinoCore-API/api/ArduinoAPI.h ;
-
 printf '%s\n' "Linking...";
 ln -sf ~/.ArduinoCore-API/api cores/arduino/. ;
 


### PR DESCRIPTION
The issue has now been resolved, and we no longer need to comment out that library.