### PR TITLE
Implement interrupts and noInterrupts

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -97,6 +97,9 @@ enum analogPins { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user),
 
 #endif
 
+void interrupts(void);
+void noInterrupts(void);
+
 #include <variant.h>
 #ifdef __cplusplus
 #include <zephyrPrint.h>

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -175,6 +175,22 @@ size_t analog_pin_index(pin_size_t pinNumber) {
 
 #endif //CONFIG_ADC
 
+static unsigned int irq_key;
+static bool interrupts_disabled = false;
+
+void interrupts(void) {
+  if (interrupts_disabled) {
+    irq_unlock(irq_key);
+    interrupts_disabled = false;
+  }
+}
+
+void noInterrupts(void) {
+  if (!interrupts_disabled) {
+    irq_key = irq_lock();
+    interrupts_disabled = true;
+  }
+}
 }
 
 void yield(void) {


### PR DESCRIPTION
- Using irq_lock and irq_unlock zephyr apis.
- Not really sure where these should go. `Common.h` has the following line:
```
// interrupts() / noInterrupts() must be defined by the core
```
- Need these for the [NeoPixel library](https://github.com/adafruit/Adafruit_NeoPixel).