### PR TITLE
Arduino.h: Add digitalPinToInterrupt

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -100,6 +100,8 @@ enum analogPins { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user),
 void interrupts(void);
 void noInterrupts(void);
 
+int digitalPinToInterrupt(pin_size_t pin);
+
 #include <variant.h>
 #ifdef __cplusplus
 #include <zephyrPrint.h>

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -480,3 +480,10 @@ void noInterrupts(void) {
     interrupts_disabled = true;
   }
 }
+
+int digitalPinToInterrupt(pin_size_t pin) {
+  struct gpio_port_callback *pcb =
+      find_gpio_port_callback(arduino_pins[pin].port);
+
+  return (pcb) ? pin : -1;
+}


### PR DESCRIPTION
- Return the same number as long as not more than number of digital pins.
- This does not seem to be present in ArduinoCoreAPI but defined for all Arduino boards (and microblocks has started using it).
- Also present in arduino docs [1]

[1]: https://www.arduino.cc/reference/en/language/functions/external-interrupts/digitalpintointerrupt/