### PR TITLE
zephyrCommon: Change `delayMicroseconds` to busy loop

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -259,7 +259,9 @@ void noTone(pin_size_t pinNumber) {
 
 void delay(unsigned long ms) { k_sleep(K_MSEC(ms)); }
 
-void delayMicroseconds(unsigned int us) { k_sleep(K_USEC(us)); }
+void delayMicroseconds(unsigned int us) {
+  k_busy_wait(us);
+}
 
 unsigned long micros(void) {
   return k_cyc_to_us_floor32(k_cycle_get_32());

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -257,7 +257,9 @@ void noTone(pin_size_t pinNumber) {
   gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
 }
 
-void delay(unsigned long ms) { k_sleep(K_MSEC(ms)); }
+void delay(unsigned long ms) {
+  k_sleep(K_MSEC(ms));
+}
 
 void delayMicroseconds(unsigned int us) {
   k_busy_wait(us);
@@ -267,7 +269,9 @@ unsigned long micros(void) {
   return k_cyc_to_us_floor32(k_cycle_get_32());
 }
 
-unsigned long millis(void) { return k_uptime_get_32(); }
+unsigned long millis(void) {
+  return k_uptime_get_32();
+}
 
 #ifdef CONFIG_PWM
 


### PR DESCRIPTION
Since Arduino's `delayMicroseconds` is implemented as a busy loop,
we change it to using `k_busy_wait` to improve compatibility.