### PR TITLE
zephyrCommon: Removed pulseIn GPIO direction check

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -407,8 +407,6 @@ long random(long max) {
 
 #endif
 
-#ifdef CONFIG_GPIO_GET_DIRECTION
-
 unsigned long pulseIn(pin_size_t pinNumber, uint8_t state, unsigned long timeout) {
   struct k_timer timer;
   int64_t start, end, delta = 0;
@@ -418,10 +416,6 @@ unsigned long pulseIn(pin_size_t pinNumber, uint8_t state, unsigned long timeout
   k_timer_start(&timer, K_MSEC(timeout), K_NO_WAIT);
 
   if (!gpio_is_ready_dt(spec)) {
-    goto cleanup;
-  }
-
-  if (!gpio_pin_is_input_dt(spec)) {
     goto cleanup;
   }
 
@@ -448,8 +442,6 @@ cleanup:
   k_timer_stop(&timer);
   return (unsigned long)delta;
 }
-
-#endif // CONFIG_GPIO_GET_DIRECTION
 
 void enableInterrupt(pin_size_t pinNumber) {
   struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);


### PR DESCRIPTION
Since the general Arduino implementation does not check the GPIO direction, this check has been removed to improve compatibility.