### PR TITLE
zephyrCommon: Fix PWM index range check

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -273,11 +273,11 @@ void analogWrite(pin_size_t pinNumber, int value)
 {
   size_t idx = pwm_pin_index(pinNumber);
 
-  if (!pwm_is_ready_dt(&arduino_pwm[idx])) {
+  if (idx >= ARRAY_SIZE(arduino_pwm)) {
     return;
   }
 
-  if (idx >= ARRAY_SIZE(arduino_pwm) ) {
+  if (!pwm_is_ready_dt(&arduino_pwm[idx])) {
     return;
   }
 


### PR DESCRIPTION
The PWM index range check processing was performed after the index was referenced, so it was now performed first.