### PR TITLE
zephyrCommon: Immediately terminate pulseIn if gpio not ready

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -418,12 +418,12 @@ unsigned long pulseIn(pin_size_t pinNumber, uint8_t state, unsigned long timeout
   int64_t start, end, delta = 0;
   const struct gpio_dt_spec *spec = &arduino_pins[pinNumber];
 
+  if (!gpio_is_ready_dt(spec)) {
+    return 0;
+  }
+
   k_timer_init(&timer, NULL, NULL);
   k_timer_start(&timer, K_MSEC(timeout), K_NO_WAIT);
-
-  if (!gpio_is_ready_dt(spec)) {
-    goto cleanup;
-  }
 
   while(gpio_pin_get_dt(spec) == state && k_timer_status_get(&timer) == 0);
   if (k_timer_status_get(&timer) > 0) {


### PR DESCRIPTION
If gpio is not initialized, the pulseIn function will terminate
without running the timer.