### PR TITLE
zephyrCommon: Add comment at the end of the anonymous namespace

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -177,7 +177,7 @@ size_t analog_pin_index(pin_size_t pinNumber) {
 
 static unsigned int irq_key;
 static bool interrupts_disabled = false;
-}
+}  // namespace
 
 void yield(void) {
   k_yield();


### PR DESCRIPTION
Added a comment because it was difficult to understand where the namespace ends.