### PR TITLE
zephyrCommon: Fixed a bug in the interrupt handler acquisition

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -104,7 +104,7 @@ void setInterruptHandler(pin_size_t pinNumber, voidFuncPtr func)
   struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
   if (pcb) {
-    pcb->handlers[BIT(arduino_pins[pinNumber].pin)].handler = func;
+    pcb->handlers[arduino_pins[pinNumber].pin].handler = func;
   }
 }
 
@@ -113,8 +113,8 @@ void handleGpioCallback(const struct device *port, struct gpio_callback *cb, uin
   struct gpio_port_callback *pcb = (struct gpio_port_callback *)cb;
 
   for (uint32_t i = 0; i < max_ngpios; i++) {
-    if (pins & BIT(i) && pcb->handlers[BIT(i)].enabled) {
-      pcb->handlers[BIT(i)].handler();
+    if (pins & BIT(i) && pcb->handlers[i].enabled) {
+      pcb->handlers[i].handler();
     }
   }
 }
@@ -455,7 +455,7 @@ void enableInterrupt(pin_size_t pinNumber) {
   struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
   if (pcb) {
-    pcb->handlers[BIT(arduino_pins[pinNumber].pin)].enabled = true;
+    pcb->handlers[arduino_pins[pinNumber].pin].enabled = true;
   }
 }
 
@@ -463,7 +463,7 @@ void disableInterrupt(pin_size_t pinNumber) {
   struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
   if (pcb) {
-    pcb->handlers[BIT(arduino_pins[pinNumber].pin)].enabled = false;
+    pcb->handlers[arduino_pins[pinNumber].pin].enabled = false;
   }
 }
 


### PR DESCRIPTION
Fixed an issue where the reference location for the interrupt handler was a bit mask instead of an index value.