### PR TITLE
Imporove CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/variants/${BOARD})
-  set(variant_dir variants/${BOARD})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
+if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
   set(variant_dir variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
 else()
-  message(FATAL_ERROR "Variant dir not found: variants/${BOARD}, variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS}")
+  message(FATAL_ERROR "Variant dir not found: variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS}")
 endif()
 
 if (CONFIG_ARDUINO_API)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
-  set(variant_dir variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
-else()
-  message(FATAL_ERROR "Variant dir not found: variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS}")
-endif()
-
 if (CONFIG_ARDUINO_API)
-add_subdirectory(cores)
-add_subdirectory(libraries)
-zephyr_include_directories(${variant_dir})
-endif()
+  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
+    set(variant_dir variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS})
+  else()
+    message(FATAL_ERROR "Variant dir not found: variants/${BOARD}${NORMALIZED_BOARD_QUALIFIERS}")
+  endif()
 
+  add_subdirectory(cores)
+  add_subdirectory(libraries)
+  zephyr_include_directories(${variant_dir})
+endif()


### PR DESCRIPTION
Use normalized board names to simplify variant discovery
Skip variant checking when using the API