### PR TITLE
workflows: Add clang format check workflow.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Note: The list of ForEachMacros can be obtained using:
+#
+#    git grep -h '^#define [^[:space:]]*FOR_EACH[^[:space:]]*(' include/ \
+#    | sed "s,^#define \([^[:space:]]*FOR_EACH[^[:space:]]*\)(.*$,  - '\1'," \
+#    | sort | uniq
+#
+# References:
+#   - https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+---
+BasedOnStyle: LLVM
+AlignOperands: Align
+BreakBeforeTernaryOperators: false
+EmptyLineBeforeAccessModifier: LogicalBlock
+AlignConsecutiveMacros: AcrossComments
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AttributeMacros:
+  - __aligned
+  - __deprecated
+  - __packed
+  - __printf_like
+  - __syscall
+  - __syscall_always_inline
+  - __subsystem
+BitFieldColonSpacing: After
+BreakBeforeBraces: Attach
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+ForEachMacros:
+  - 'ARRAY_FOR_EACH'
+  - 'ARRAY_FOR_EACH_PTR'
+  - 'FOR_EACH'
+  - 'FOR_EACH_FIXED_ARG'
+  - 'FOR_EACH_IDX'
+  - 'FOR_EACH_IDX_FIXED_ARG'
+  - 'FOR_EACH_NONEMPTY_TERM'
+  - 'FOR_EACH_FIXED_ARG_NONEMPTY_TERM'
+  - 'RB_FOR_EACH'
+  - 'RB_FOR_EACH_CONTAINER'
+  - 'SYS_DLIST_FOR_EACH_CONTAINER'
+  - 'SYS_DLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_DLIST_FOR_EACH_NODE'
+  - 'SYS_DLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SEM_LOCK'
+  - 'SYS_SFLIST_FOR_EACH_CONTAINER'
+  - 'SYS_SFLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_SFLIST_FOR_EACH_NODE'
+  - 'SYS_SFLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SLIST_FOR_EACH_CONTAINER'
+  - 'SYS_SLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_SLIST_FOR_EACH_NODE'
+  - 'SYS_SLIST_FOR_EACH_NODE_SAFE'
+  - '_WAIT_Q_FOR_EACH'
+  - 'Z_FOR_EACH'
+  - 'Z_FOR_EACH_ENGINE'
+  - 'Z_FOR_EACH_EXEC'
+  - 'Z_FOR_EACH_FIXED_ARG'
+  - 'Z_FOR_EACH_FIXED_ARG_EXEC'
+  - 'Z_FOR_EACH_IDX'
+  - 'Z_FOR_EACH_IDX_EXEC'
+  - 'Z_FOR_EACH_IDX_FIXED_ARG'
+  - 'Z_FOR_EACH_IDX_FIXED_ARG_EXEC'
+  - 'Z_GENLIST_FOR_EACH_CONTAINER'
+  - 'Z_GENLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'Z_GENLIST_FOR_EACH_NODE'
+  - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
+  - 'STRUCT_SECTION_FOREACH'
+  - 'STRUCT_SECTION_FOREACH_ALTERNATE'
+  - 'TYPE_SECTION_FOREACH'
+  - 'K_SPINLOCK'
+  - 'COAP_RESOURCE_FOREACH'
+  - 'COAP_SERVICE_FOREACH'
+  - 'COAP_SERVICE_FOREACH_RESOURCE'
+  - 'HTTP_RESOURCE_FOREACH'
+  - 'HTTP_SERVER_CONTENT_TYPE_FOREACH'
+  - 'HTTP_SERVICE_FOREACH'
+  - 'HTTP_SERVICE_FOREACH_RESOURCE'
+  - 'I3C_BUS_FOR_EACH_I3CDEV'
+  - 'I3C_BUS_FOR_EACH_I2CDEV'
+  - 'MIN_HEAP_FOREACH'
+IfMacros:
+  - 'CHECKIF'
+IncludeCategories:
+  - Regex: '^".*\.h"$'
+    Priority: 0
+  - Regex: '^<(assert|complex|ctype|errno|fenv|float|inttypes|limits|locale|math|setjmp|signal|stdarg|stdbool|stddef|stdint|stdio|stdlib|string|tgmath|time|wchar|wctype)\.h>$'
+    Priority: 1
+  - Regex: '^\<zephyr/.*\.h\>$'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentAccessModifiers: false
+AccessModifierOffset: -4
+IndentWidth: 4
+InsertBraces: true
+InsertNewlineAtEOF: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SortIncludes: Never
+SeparateDefinitionBlocks: Always
+UseTab: ForContinuationAndIndentation
+TabWidth: 4
+WhitespaceSensitiveMacros:
+  - COND_CODE_0
+  - COND_CODE_1
+  - IF_DISABLED
+  - IF_ENABLED
+  - LISTIFY
+  - STRINGIFY
+  - Z_STRINGIFY
+  - DT_FOREACH_PROP_ELEM_SEP

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,0 +1,62 @@
+name: 'Format Check'
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - 'main'
+    paths:
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - check: 'cores/arduino/'
+            exclude: 'cores/arduino/api/'
+          - check: 'loader/'
+            exclude: 'loader/llext_exports\.c$'
+          - check: 'libraries/'
+            exclude: 'examples'
+            exclude: 'extras'
+            exclude: 'ea_malloc'
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Run clang-format check
+        uses: jidicula/clang-format-action@v4.15.0
+        with:
+          clang-format-version: '19'
+          check-path: ${{ matrix.path['check'] }}
+          exclude-regex: ${{ matrix.path['exclude'] }}


### PR DESCRIPTION
Cherry-pick the commit adding .clang-format from https://github.com/arduino/ArduinoCore-zephyr.