### PR TITLE
External overlays support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ if (CONFIG_ARDUINO_API)
   elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/variants/${NORMALIZED_BOARD_TARGET})
     set(variant_dir variants/${NORMALIZED_BOARD_TARGET})
   else()
-    message(FATAL_ERROR "Variant dir not found: variants/${BOARD}, variants/${NORMALIZED_BOARD_TARGET}")
+    message(WARNING
+      "Variant dir not found: variants/${BOARD}, variants/${NORMALIZED_BOARD_TARGET}\n"
+      "Your board is currently not supported. To use it you must create a DTS overlay."
+    )
+    set(variant_dir variants/default)
   endif()
 
   add_subdirectory(cores)

--- a/documentation/variants.md
+++ b/documentation/variants.md
@@ -38,6 +38,8 @@ variants/
 │   ├── variant.h
 ```
 
+It is possible to apply the overlay outside of the `variants` folder. In that case `cmake` will show a warning and a default empty `variant.h` file will be used. The `zephyr,user` section will still need to be defined somewhere in your project, as described in the [Guide to Writing Overlays section](#guide-to-writing-overlays).
+
 ## Guide to Writing Overlays
 
 ### DeviceTree Overlay files for Arduino boards

--- a/variants/default/variant.h
+++ b/variants/default/variant.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 Michal Gagos
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once


### PR DESCRIPTION
I am currently working on a project where I use `ArduinoCore` as a module in order to use arduino libraries. I am using an `AtomS3` board and I don't want to add it explicitly to the `ArduinoCore/variants`.

These changes will allow the user to provide their own overlay in their project without having to modify the library pulled in by west. If they don't provide an overlay their build will fail anyways due to missing `zephyr,user` section.

If this is not the right approach would adding the `AtomS3` board to the variants be a good PR?