### PR TITLE
zephyrCommon: improve delay* accurancy

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -116,6 +116,8 @@ int digitalPinToInterrupt(pin_size_t pin);
 #define LED_BUILTIN ZARD_LED_BUILTIN
 #endif // LED_BUILTIN
 
+#include <inlines.h>
+
 #ifdef __cplusplus
 #include <zephyrSerial.h>
 #endif // __cplusplus

--- a/cores/arduino/inlines.h
+++ b/cores/arduino/inlines.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Provide implementations for inline functions.
+ */
+
+#ifndef __INLINES_H__
+#define __INLINES_H__
+
+#include <zephyr/kernel.h>
+
+inline __attribute__((always_inline)) void delay(unsigned long ms) {
+	k_sleep(K_MSEC(ms));
+}
+
+inline __attribute__((always_inline)) void delayMicroseconds(unsigned int us) {
+	if (us == 0) {
+		return;
+	}
+	k_busy_wait(us - 1);
+}
+
+#endif /* __INLINES_H__ */

--- a/cores/arduino/time_macros.h
+++ b/cores/arduino/time_macros.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <zephyr/sys/time_units.h>
+
+#define clockCyclesPerMicrosecond()  (1000000 / k_cyc_to_ns_near64(1000))
+#define clockCyclesToMicroseconds(a) (a / clockCyclesPerMicrosecond())
+#define microsecondsToClockCycles(a) (a * clockCyclesPerMicrosecond())

--- a/cores/arduino/time_macros.h
+++ b/cores/arduino/time_macros.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include <zephyr/sys/time_units.h>

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -338,17 +338,6 @@ void noTone(pin_size_t pinNumber) {
 	gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
 }
 
-__attribute__((always_inline)) void delay(unsigned long ms) {
-  k_sleep(K_MSEC(ms));
-}
-
-__attribute__((always_inline)) void delayMicroseconds(unsigned int us) {
-  if (us == 0) {
-    return;
-  }
-  k_busy_wait(us - 1);
-}
-
 unsigned long micros(void) {
 #ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
 	return k_cyc_to_us_floor32(k_cycle_get_64());

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -338,12 +338,15 @@ void noTone(pin_size_t pinNumber) {
 	gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
 }
 
-void delay(unsigned long ms) {
-	k_sleep(K_MSEC(ms));
+__attribute__((always_inline)) void delay(unsigned long ms) {
+  k_sleep(K_MSEC(ms));
 }
 
-void delayMicroseconds(unsigned int us) {
-	k_busy_wait(us);
+__attribute__((always_inline)) void delayMicroseconds(unsigned int us) {
+  if (us == 0) {
+    return;
+  }
+  k_busy_wait(us - 1);
 }
 
 unsigned long micros(void) {


### PR DESCRIPTION
experimental results here https://github.com/arduino/ArduinoCore-zephyr/issues/332#issuecomment-3907809199

On boards with different clock speed, function call overhead etc. the results may vary but will likely be consistent, given that all the boards share CONFIG_SYS_CLOCK_TICKS_PER_SEC


-------

You may be unhappy with the format of the commit,
but please bear with us until the merge is complete.
