### PR TITLE
cores: arduino: Format with clang-format

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -15,16 +15,15 @@
 #include <zephyr/drivers/i2c.h>
 
 #define DIGITAL_PIN_EXISTS(n, p, i, dev, num)                                                      \
-	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) &&                                      \
-	  (num == DT_PHA_BY_IDX(n, p, i, pin)))                                                    \
-		 ? 1                                                                               \
-		 : 0)
+	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) && (num == DT_PHA_BY_IDX(n, p, i, pin))) ?  \
+		 1 :                                                                                       \
+		 0)
 
 /* Check all pins are defined only once */
 #define DIGITAL_PIN_CHECK_UNIQUE(i, _)                                                             \
-	((DT_FOREACH_PROP_ELEM_SEP_VARGS(                                                          \
-		 DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS, (+),                 \
-		 DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), digital_pin_gpios, i)),       \
+	((DT_FOREACH_PROP_ELEM_SEP_VARGS(                                                              \
+		 DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS, (+),                         \
+		 DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), digital_pin_gpios, i)),               \
 		 DT_PHA_BY_IDX(DT_PATH(zephyr_user), digital_pin_gpios, i, pin))) == 1)
 
 #if !LISTIFY(DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios), DIGITAL_PIN_CHECK_UNIQUE, (&&))
@@ -38,17 +37,17 @@
 	(DIGITAL_PIN_EXISTS(n, p, i, dev, num) ? i : 0)
 
 /* Only matched pin returns non-zero value, so the sum is matched pin's index */
-#define DIGITAL_PIN_GPIOS_FIND_PIN(dev, pin)                                                     \
-	DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(zephyr_user), digital_pin_gpios,                    \
-				       LED_BUILTIN_INDEX_BY_REG_AND_PINNUM, (+), dev, pin)
+#define DIGITAL_PIN_GPIOS_FIND_PIN(dev, pin)                                                       \
+	DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(zephyr_user), digital_pin_gpios,                        \
+								   LED_BUILTIN_INDEX_BY_REG_AND_PINNUM, (+), dev, pin)
 
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), builtin_led_gpios) &&                                   \
 	(DT_PROP_LEN(DT_PATH(zephyr_user), builtin_led_gpios) > 0)
 
-#if !(DT_FOREACH_PROP_ELEM_SEP_VARGS(                                                               \
-	     DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS, (+),                     \
-	     DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0)),           \
-	     DT_PHA_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0, pin)) > 0)
+#if !(DT_FOREACH_PROP_ELEM_SEP_VARGS(                                                              \
+		  DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS, (+),                        \
+		  DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0)),              \
+		  DT_PHA_BY_IDX(DT_PATH(zephyr_user), builtin_led_gpios, 0, pin)) > 0)
 #warning "pin not found in digital_pin_gpios"
 #else
 #define ZARD_LED_BUILTIN                                                                           \
@@ -60,9 +59,10 @@
 /* If digital-pin-gpios is not defined, tries to use the led0 alias */
 #elif DT_NODE_EXISTS(DT_ALIAS(led0))
 
-#if !(DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS,   \
-				    (+), DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_ALIAS(led0), gpios, 0)), \
-				    DT_PHA_BY_IDX(DT_ALIAS(led0), gpios, 0, pin)) > 0)
+#if !(DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(zephyr_user), digital_pin_gpios, DIGITAL_PIN_EXISTS,  \
+									 (+),                                                          \
+									 DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_ALIAS(led0), gpios, 0)),     \
+									 DT_PHA_BY_IDX(DT_ALIAS(led0), gpios, 0, pin)) > 0)
 #warning "pin not found in digital_pin_gpios"
 #else
 #define ZARD_LED_BUILTIN                                                                           \
@@ -85,11 +85,13 @@ enum digitalPins {
 
 #ifdef CONFIG_ADC
 
-#define AN_ENUMS(n, p, i) A ## i = DIGITAL_PIN_GPIOS_FIND_PIN( \
-		DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),        \
-		DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
-enum analogPins { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user),
-				       adc_pin_gpios, AN_ENUMS) };
+#define AN_ENUMS(n, p, i)                                                                          \
+	A##i = DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),  \
+									  DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
+
+enum analogPins {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), adc_pin_gpios, AN_ENUMS)
+};
 
 #endif
 

--- a/cores/arduino/apiCommon.cpp
+++ b/cores/arduino/apiCommon.cpp
@@ -8,19 +8,19 @@
 #include "zephyrInternal.h"
 
 extern "C" {
-  int32_t map_i32(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max);
-  uint16_t makeWord_w(uint16_t w);
-  uint16_t makeWord_hl(byte h, byte l);
+int32_t map_i32(int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max);
+uint16_t makeWord_w(uint16_t w);
+uint16_t makeWord_hl(byte h, byte l);
 }
 
-long map(long x, long in_min, long in_max, long out_min, long out_max)
-{
-  return map_i32(x, in_min, in_max, out_min, out_max);
+long map(long x, long in_min, long in_max, long out_min, long out_max) {
+	return map_i32(x, in_min, in_max, out_min, out_max);
 }
 
 uint16_t makeWord(uint16_t w) {
-  return makeWord_w(w);
+	return makeWord_w(w);
 }
+
 uint16_t makeWord(byte h, byte l) {
-  return makeWord_hl(h, l);
+	return makeWord_hl(h, l);
 }

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -7,12 +7,14 @@
 #include "Arduino.h"
 
 int main(void) {
-  setup();
+	setup();
 
-  for (;;) {
-    loop();
-    if (arduino::serialEventRun) arduino::serialEventRun();
-  }
+	for (;;) {
+		loop();
+		if (arduino::serialEventRun) {
+			arduino::serialEventRun();
+		}
+	}
 
-  return 0;
+	return 0;
 }

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -9,7 +9,8 @@
 
 #include <zephyr/spinlock.h>
 
-static const struct gpio_dt_spec arduino_pins[] = {DT_FOREACH_PROP_ELEM_SEP(
+static const struct gpio_dt_spec arduino_pins[] = {
+	DT_FOREACH_PROP_ELEM_SEP(
 	DT_PATH(zephyr_user), digital_pin_gpios, GPIO_DT_SPEC_GET_BY_IDX, (, ))};
 
 namespace {
@@ -18,171 +19,159 @@ namespace {
  * Calculate GPIO ports/pins number statically from devicetree configuration
  */
 
-template <class N, class Head> constexpr const N sum_of_list(const N sum, const Head &head)
-{
-  return sum + head;
+template <class N, class Head> constexpr const N sum_of_list(const N sum, const Head &head) {
+	return sum + head;
 }
 
 template <class N, class Head, class... Tail>
-constexpr const N sum_of_list(const N sum, const Head &head, const Tail &...tail)
-{
-  return sum_of_list(sum + head, tail...);
+constexpr const N sum_of_list(const N sum, const Head &head, const Tail &...tail) {
+	return sum_of_list(sum + head, tail...);
 }
 
-template <class N, class Head> constexpr const N max_in_list(const N max, const Head &head)
-{
-  return (max >= head) ? max : head;
+template <class N, class Head> constexpr const N max_in_list(const N max, const Head &head) {
+	return (max >= head) ? max : head;
 }
 
 template <class N, class Head, class... Tail>
-constexpr const N max_in_list(const N max, const Head &head, const Tail &...tail)
-{
-  return max_in_list((max >= head) ? max : head, tail...);
+constexpr const N max_in_list(const N max, const Head &head, const Tail &...tail) {
+	return max_in_list((max >= head) ? max : head, tail...);
 }
 
 template <class Query, class Head>
 constexpr const size_t is_first_appearance(const size_t &idx, const size_t &at, const size_t &found,
-             const Query &query, const Head &head)
-{
-  return ((found == ((size_t)-1)) && (query == head) && (idx == at)) ? 1 : 0;
+										   const Query &query, const Head &head) {
+	return ((found == ((size_t)-1)) && (query == head) && (idx == at)) ? 1 : 0;
 }
 
 template <class Query, class Head, class... Tail>
 constexpr const size_t is_first_appearance(const size_t &idx, const size_t &at, const size_t &found,
-             const Query &query, const Head &head,
-             const Tail &...tail)
-{
-  return ((found == ((size_t)-1)) && (query == head) && (idx == at))
-           ? 1
-           : is_first_appearance(idx + 1, at, (query == head ? idx : found), query,
-               tail...);
+										   const Query &query, const Head &head,
+										   const Tail &...tail) {
+	return ((found == ((size_t)-1)) && (query == head) && (idx == at)) ?
+			   1 :
+			   is_first_appearance(idx + 1, at, (query == head ? idx : found), query, tail...);
 }
 
 #define GET_DEVICE_VARGS(n, p, i, _) DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(n, p, i))
 #define FIRST_APPEARANCE(n, p, i)                                                                  \
-  is_first_appearance(0, i, ((size_t)-1), DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(n, p, i)),       \
-          DT_FOREACH_PROP_ELEM_SEP_VARGS(n, p, GET_DEVICE_VARGS, (, ), 0))
-const int port_num =
-  sum_of_list(0, DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios,
+	is_first_appearance(0, i, ((size_t)-1), DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(n, p, i)),           \
+						DT_FOREACH_PROP_ELEM_SEP_VARGS(n, p, GET_DEVICE_VARGS, (, ), 0))
+const int port_num = sum_of_list(
+	0, DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios,
             FIRST_APPEARANCE, (, )));
 
 #define GPIO_NGPIOS(n, p, i) DT_PROP(DT_GPIO_CTLR_BY_IDX(n, p, i), ngpios)
 const int max_ngpios = max_in_list(
-  0, DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios, GPIO_NGPIOS, (, )));
+	0, DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios, GPIO_NGPIOS, (, )));
 
 /*
  * GPIO callback implementation
  */
 
 struct arduino_callback {
-  voidFuncPtr handler;
-  bool enabled;
+	voidFuncPtr handler;
+	bool enabled;
 };
 
 struct gpio_port_callback {
-  struct gpio_callback callback;
-  struct arduino_callback handlers[max_ngpios];
-  gpio_port_pins_t pins;
-  const struct device *dev;
+	struct gpio_callback callback;
+	struct arduino_callback handlers[max_ngpios];
+	gpio_port_pins_t pins;
+	const struct device *dev;
 } port_callback[port_num] = {0};
 
-struct gpio_port_callback *find_gpio_port_callback(const struct device *dev)
-{
-  for (size_t i = 0; i < ARRAY_SIZE(port_callback); i++) {
-    if (port_callback[i].dev == dev) {
-      return &port_callback[i];
-    }
-    if (port_callback[i].dev == nullptr) {
-      port_callback[i].dev = dev;
-      return &port_callback[i];
-    }
-  }
+struct gpio_port_callback *find_gpio_port_callback(const struct device *dev) {
+	for (size_t i = 0; i < ARRAY_SIZE(port_callback); i++) {
+		if (port_callback[i].dev == dev) {
+			return &port_callback[i];
+		}
+		if (port_callback[i].dev == nullptr) {
+			port_callback[i].dev = dev;
+			return &port_callback[i];
+		}
+	}
 
-  return nullptr;
+	return nullptr;
 }
 
-void setInterruptHandler(pin_size_t pinNumber, voidFuncPtr func)
-{
-  struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
+void setInterruptHandler(pin_size_t pinNumber, voidFuncPtr func) {
+	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
-  if (pcb) {
-    pcb->handlers[arduino_pins[pinNumber].pin].handler = func;
-  }
+	if (pcb) {
+		pcb->handlers[arduino_pins[pinNumber].pin].handler = func;
+	}
 }
 
-void handleGpioCallback(const struct device *port, struct gpio_callback *cb, uint32_t pins)
-{
-  struct gpio_port_callback *pcb = (struct gpio_port_callback *)cb;
+void handleGpioCallback(const struct device *port, struct gpio_callback *cb, uint32_t pins) {
+	struct gpio_port_callback *pcb = (struct gpio_port_callback *)cb;
 
-  for (uint32_t i = 0; i < max_ngpios; i++) {
-    if (pins & BIT(i) && pcb->handlers[i].enabled) {
-      pcb->handlers[i].handler();
-    }
-  }
+	for (uint32_t i = 0; i < max_ngpios; i++) {
+		if (pins & BIT(i) && pcb->handlers[i].enabled) {
+			pcb->handlers[i].handler();
+		}
+	}
 }
 
 #ifdef CONFIG_PWM
 
-#define PWM_DT_SPEC(n,p,i) PWM_DT_SPEC_GET_BY_IDX(n, i),
-#define PWM_PINS(n, p, i) \
-	DIGITAL_PIN_GPIOS_FIND_PIN( \
-                DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),        \
-                DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
+#define PWM_DT_SPEC(n, p, i) PWM_DT_SPEC_GET_BY_IDX(n, i),
+#define PWM_PINS(n, p, i)                                                                          \
+	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),         \
+							   DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
 
-const struct pwm_dt_spec arduino_pwm[] =
-	{ DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwms, PWM_DT_SPEC) };
+const struct pwm_dt_spec arduino_pwm[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwms, PWM_DT_SPEC)};
 
 /* pwm-pins node provides a mapping digital pin numbers to pwm channels */
-const pin_size_t arduino_pwm_pins[] =
-	{ DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwm_pin_gpios, PWM_PINS) };
+const pin_size_t arduino_pwm_pins[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwm_pin_gpios, PWM_PINS)};
 
 size_t pwm_pin_index(pin_size_t pinNumber) {
-  for(size_t i=0; i<ARRAY_SIZE(arduino_pwm_pins); i++) {
-    if (arduino_pwm_pins[i] == pinNumber) {
-      return i;
-    }
-  }
-  return (size_t)-1;
+	for (size_t i = 0; i < ARRAY_SIZE(arduino_pwm_pins); i++) {
+		if (arduino_pwm_pins[i] == pinNumber) {
+			return i;
+		}
+	}
+	return (size_t)-1;
 }
 
-#endif //CONFIG_PWM
+#endif // CONFIG_PWM
 
 #ifdef CONFIG_ADC
 
-#define ADC_DT_SPEC(n,p,i) ADC_DT_SPEC_GET_BY_IDX(n, i),
-#define ADC_PINS(n, p, i) \
-	DIGITAL_PIN_GPIOS_FIND_PIN( \
-                DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),        \
-                DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
-#define ADC_CH_CFG(n,p,i) arduino_adc[i].channel_cfg,
+#define ADC_DT_SPEC(n, p, i) ADC_DT_SPEC_GET_BY_IDX(n, i),
+#define ADC_PINS(n, p, i)                                                                          \
+	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), p, i)),         \
+							   DT_PHA_BY_IDX(DT_PATH(zephyr_user), p, i, pin)),
+#define ADC_CH_CFG(n, p, i) arduino_adc[i].channel_cfg,
 
-const struct adc_dt_spec arduino_adc[] =
-  { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_DT_SPEC) };
+const struct adc_dt_spec arduino_adc[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_DT_SPEC)};
 
 /* io-channel-pins node provides a mapping digital pin numbers to adc channels */
-const pin_size_t arduino_analog_pins[] =
-  { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), adc_pin_gpios, ADC_PINS) };
+const pin_size_t arduino_analog_pins[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), adc_pin_gpios, ADC_PINS)};
 
-struct adc_channel_cfg channel_cfg[ARRAY_SIZE(arduino_analog_pins)] =
-  { DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_CH_CFG) };
+struct adc_channel_cfg channel_cfg[ARRAY_SIZE(arduino_analog_pins)] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, ADC_CH_CFG)};
 
 size_t analog_pin_index(pin_size_t pinNumber) {
-  for(size_t i=0; i<ARRAY_SIZE(arduino_analog_pins); i++) {
-    if (arduino_analog_pins[i] == pinNumber) {
-      return i;
-    }
-  }
-  return (size_t)-1;
+	for (size_t i = 0; i < ARRAY_SIZE(arduino_analog_pins); i++) {
+		if (arduino_analog_pins[i] == pinNumber) {
+			return i;
+		}
+	}
+	return (size_t)-1;
 }
 
-#endif //CONFIG_ADC
+#endif // CONFIG_ADC
 
 static unsigned int irq_key;
 static bool interrupts_disabled = false;
-}  // namespace
+} // namespace
 
 void yield(void) {
-  k_yield();
+	k_yield();
 }
 
 /*
@@ -191,27 +180,25 @@ void yield(void) {
  *  A high physical level will be interpreted as value 1
  */
 void pinMode(pin_size_t pinNumber, PinMode pinMode) {
-  if (pinMode == INPUT) { // input mode
-    gpio_pin_configure_dt(&arduino_pins[pinNumber],
-                          GPIO_INPUT | GPIO_ACTIVE_HIGH);
-  } else if (pinMode == INPUT_PULLUP) { // input with internal pull-up
-    gpio_pin_configure_dt(&arduino_pins[pinNumber],
-                          GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
-  } else if (pinMode == INPUT_PULLDOWN) { // input with internal pull-down
-    gpio_pin_configure_dt(&arduino_pins[pinNumber],
-                          GPIO_INPUT | GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH);
-  } else if (pinMode == OUTPUT) { // output mode
-    gpio_pin_configure_dt(&arduino_pins[pinNumber],
-                          GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
-  }
+	if (pinMode == INPUT) { // input mode
+		gpio_pin_configure_dt(&arduino_pins[pinNumber], GPIO_INPUT | GPIO_ACTIVE_HIGH);
+	} else if (pinMode == INPUT_PULLUP) { // input with internal pull-up
+		gpio_pin_configure_dt(&arduino_pins[pinNumber],
+							  GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
+	} else if (pinMode == INPUT_PULLDOWN) { // input with internal pull-down
+		gpio_pin_configure_dt(&arduino_pins[pinNumber],
+							  GPIO_INPUT | GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH);
+	} else if (pinMode == OUTPUT) { // output mode
+		gpio_pin_configure_dt(&arduino_pins[pinNumber], GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+	}
 }
 
 void digitalWrite(pin_size_t pinNumber, PinStatus status) {
-  gpio_pin_set_dt(&arduino_pins[pinNumber], status);
+	gpio_pin_set_dt(&arduino_pins[pinNumber], status);
 }
 
 PinStatus digitalRead(pin_size_t pinNumber) {
-  return (gpio_pin_get_dt(&arduino_pins[pinNumber]) == 1) ? HIGH : LOW;
+	return (gpio_pin_get_dt(&arduino_pins[pinNumber]) == 1) ? HIGH : LOW;
 }
 
 #if CONFIG_ARDUINO_MAX_TONES < 0
@@ -223,262 +210,257 @@ PinStatus digitalRead(pin_size_t pinNumber) {
 #define TOGGLES_PER_CYCLE 2ULL
 
 static struct pin_timer {
-  struct k_timer timer;
-  uint32_t count{0};
-  pin_size_t pin{pin_size_t(-1)};
-  bool infinity{false};
-  struct k_spinlock lock;
+	struct k_timer timer;
+	uint32_t count{0};
+	pin_size_t pin{pin_size_t(-1)};
+	bool infinity{false};
+	struct k_spinlock lock;
 } arduino_pin_timers[MAX_TONE_PINS];
 
-static struct pin_timer* find_pin_timer(pin_size_t pinNumber, bool active_only) {
-  for (size_t i = 0; i < ARRAY_SIZE(arduino_pin_timers); i++) {
-    k_spinlock_key_t key = k_spin_lock(&arduino_pin_timers[i].lock);
+static struct pin_timer *find_pin_timer(pin_size_t pinNumber, bool active_only) {
+	for (size_t i = 0; i < ARRAY_SIZE(arduino_pin_timers); i++) {
+		k_spinlock_key_t key = k_spin_lock(&arduino_pin_timers[i].lock);
 
-    if (arduino_pin_timers[i].pin == pinNumber) {
-      k_spin_unlock(&arduino_pin_timers[i].lock, key);
-      return &arduino_pin_timers[i];
-    }
+		if (arduino_pin_timers[i].pin == pinNumber) {
+			k_spin_unlock(&arduino_pin_timers[i].lock, key);
+			return &arduino_pin_timers[i];
+		}
 
-    k_spin_unlock(&arduino_pin_timers[i].lock, key);
-  }
+		k_spin_unlock(&arduino_pin_timers[i].lock, key);
+	}
 
-  if (active_only) {
-    return nullptr;
-  }
+	if (active_only) {
+		return nullptr;
+	}
 
-  for (size_t i = 0; i < ARRAY_SIZE(arduino_pin_timers); i++) {
-    k_spinlock_key_t key = k_spin_lock(&arduino_pin_timers[i].lock);
+	for (size_t i = 0; i < ARRAY_SIZE(arduino_pin_timers); i++) {
+		k_spinlock_key_t key = k_spin_lock(&arduino_pin_timers[i].lock);
 
-    if (arduino_pin_timers[i].pin == pin_size_t(-1)) {
-      arduino_pin_timers[i].pin = pinNumber;
-      k_spin_unlock(&arduino_pin_timers[i].lock, key);
-      return &arduino_pin_timers[i];
-    }
+		if (arduino_pin_timers[i].pin == pin_size_t(-1)) {
+			arduino_pin_timers[i].pin = pinNumber;
+			k_spin_unlock(&arduino_pin_timers[i].lock, key);
+			return &arduino_pin_timers[i];
+		}
 
-    k_spin_unlock(&arduino_pin_timers[i].lock, key);
-  }
+		k_spin_unlock(&arduino_pin_timers[i].lock, key);
+	}
 
-  return nullptr;
+	return nullptr;
 }
 
 void tone_expiry_cb(struct k_timer *timer) {
-  struct pin_timer *pt = CONTAINER_OF(timer, struct pin_timer, timer);
-  k_spinlock_key_t key = k_spin_lock(&pt->lock);
-  pin_size_t pin = pt->pin;
+	struct pin_timer *pt = CONTAINER_OF(timer, struct pin_timer, timer);
+	k_spinlock_key_t key = k_spin_lock(&pt->lock);
+	pin_size_t pin = pt->pin;
 
-  if (pt->count == 0 && !pt->infinity) {
-    if (pin != pin_size_t(-1)) {
-      gpio_pin_set_dt(&arduino_pins[pin], 0);
-    }
+	if (pt->count == 0 && !pt->infinity) {
+		if (pin != pin_size_t(-1)) {
+			gpio_pin_set_dt(&arduino_pins[pin], 0);
+		}
 
-    k_timer_stop(timer);
-    pt->pin = pin_size_t(-1);
-  } else {
-    if (pin != pin_size_t(-1)) {
-      gpio_pin_toggle_dt(&arduino_pins[pin]);
-    }
+		k_timer_stop(timer);
+		pt->pin = pin_size_t(-1);
+	} else {
+		if (pin != pin_size_t(-1)) {
+			gpio_pin_toggle_dt(&arduino_pins[pin]);
+		}
 
-    pt->count--;
-  }
+		pt->count--;
+	}
 
-  k_spin_unlock(&pt->lock, key);
+	k_spin_unlock(&pt->lock, key);
 }
 
-void tone(pin_size_t pinNumber, unsigned int frequency,
-          unsigned long duration) {
-  k_spinlock_key_t key;
-  struct pin_timer *pt;
-  k_timeout_t timeout;
+void tone(pin_size_t pinNumber, unsigned int frequency, unsigned long duration) {
+	k_spinlock_key_t key;
+	struct pin_timer *pt;
+	k_timeout_t timeout;
 
-  pt = find_pin_timer(pinNumber, false);
+	pt = find_pin_timer(pinNumber, false);
 
-  if (pt == nullptr) {
-    return;
-  }
+	if (pt == nullptr) {
+		return;
+	}
 
-  pinMode(pinNumber, OUTPUT);
-  k_timer_stop(&pt->timer);
+	pinMode(pinNumber, OUTPUT);
+	k_timer_stop(&pt->timer);
 
-  if (frequency == 0) {
-    key = k_spin_lock(&pt->lock);
-    pt->pin = pin_size_t(-1);
-    k_spin_unlock(&pt->lock, key);
+	if (frequency == 0) {
+		key = k_spin_lock(&pt->lock);
+		pt->pin = pin_size_t(-1);
+		k_spin_unlock(&pt->lock, key);
 
-    gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
-    return;
-  }
+		gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
+		return;
+	}
 
-  timeout = K_NSEC(NSEC_PER_SEC / (TOGGLES_PER_CYCLE * frequency));
-  if (timeout.ticks == 0) {
-    timeout.ticks = 1;
-  }
+	timeout = K_NSEC(NSEC_PER_SEC / (TOGGLES_PER_CYCLE * frequency));
+	if (timeout.ticks == 0) {
+		timeout.ticks = 1;
+	}
 
-  key = k_spin_lock(&pt->lock);
-  pt->infinity = (duration == 0);
-  pt->count = min((uint64_t)duration * frequency * TOGGLES_PER_CYCLE / MSEC_PER_SEC, UINT32_MAX);
-  pt->pin = pinNumber;
-  k_spin_unlock(&pt->lock, key);
+	key = k_spin_lock(&pt->lock);
+	pt->infinity = (duration == 0);
+	pt->count = min((uint64_t)duration * frequency * TOGGLES_PER_CYCLE / MSEC_PER_SEC, UINT32_MAX);
+	pt->pin = pinNumber;
+	k_spin_unlock(&pt->lock, key);
 
-  k_timer_init(&pt->timer, tone_expiry_cb, NULL);
+	k_timer_init(&pt->timer, tone_expiry_cb, NULL);
 
-  gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
-  k_timer_start(&pt->timer, timeout, timeout);
+	gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
+	k_timer_start(&pt->timer, timeout, timeout);
 }
 
 void noTone(pin_size_t pinNumber) {
-  struct pin_timer *pt;
-  k_spinlock_key_t key;
+	struct pin_timer *pt;
+	k_spinlock_key_t key;
 
-  pt = find_pin_timer(pinNumber, true);
+	pt = find_pin_timer(pinNumber, true);
 
-  if (pt == nullptr) {
-    return;
-  }
+	if (pt == nullptr) {
+		return;
+	}
 
-  key = k_spin_lock(&pt->lock);
-  k_timer_stop(&pt->timer);
-  pt->pin = pin_size_t(-1);
-  k_spin_unlock(&pt->lock, key);
+	key = k_spin_lock(&pt->lock);
+	k_timer_stop(&pt->timer);
+	pt->pin = pin_size_t(-1);
+	k_spin_unlock(&pt->lock, key);
 
-  gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
+	gpio_pin_set_dt(&arduino_pins[pinNumber], 0);
 }
 
 void delay(unsigned long ms) {
-  k_sleep(K_MSEC(ms));
+	k_sleep(K_MSEC(ms));
 }
 
 void delayMicroseconds(unsigned int us) {
-  k_busy_wait(us);
+	k_busy_wait(us);
 }
 
 unsigned long micros(void) {
-  return k_cyc_to_us_floor32(k_cycle_get_32());
+	return k_cyc_to_us_floor32(k_cycle_get_32());
 }
 
 unsigned long millis(void) {
-  return k_uptime_get_32();
+	return k_uptime_get_32();
 }
 
 #ifdef CONFIG_PWM
 
-void analogWrite(pin_size_t pinNumber, int value)
-{
-  size_t idx = pwm_pin_index(pinNumber);
+void analogWrite(pin_size_t pinNumber, int value) {
+	size_t idx = pwm_pin_index(pinNumber);
 
-  if (idx >= ARRAY_SIZE(arduino_pwm)) {
-    return;
-  }
+	if (idx >= ARRAY_SIZE(arduino_pwm)) {
+		return;
+	}
 
-  if (!pwm_is_ready_dt(&arduino_pwm[idx])) {
-    return;
-  }
+	if (!pwm_is_ready_dt(&arduino_pwm[idx])) {
+		return;
+	}
 
-  if (((uint32_t)value) > arduino_pwm[idx].period) {
-    value = arduino_pwm[idx].period;
-  } else if (value < 0) {
-    value = 0;
-  }
+	if (((uint32_t)value) > arduino_pwm[idx].period) {
+		value = arduino_pwm[idx].period;
+	} else if (value < 0) {
+		value = 0;
+	}
 
-  /*
-   * A duty ratio determines by the period value defined in dts
-   * and the value arguments. So usually the period value sets as 255.
-   */
-  (void)pwm_set_pulse_dt(&arduino_pwm[idx], value);
+	/*
+	 * A duty ratio determines by the period value defined in dts
+	 * and the value arguments. So usually the period value sets as 255.
+	 */
+	(void)pwm_set_pulse_dt(&arduino_pwm[idx], value);
 }
 
 #endif
 
 #ifdef CONFIG_ADC
 
-void analogReference(uint8_t mode)
-{
-  /*
-   * The Arduino API not clearly defined what means of
-   * the mode argument of analogReference().
-   * Treat the value as equivalent to zephyr's adc_reference.
-   */
-  for (size_t i=0; i<ARRAY_SIZE(channel_cfg); i++) {
-    channel_cfg[i].reference = static_cast<adc_reference>(mode);
-  }
+void analogReference(uint8_t mode) {
+	/*
+	 * The Arduino API not clearly defined what means of
+	 * the mode argument of analogReference().
+	 * Treat the value as equivalent to zephyr's adc_reference.
+	 */
+	for (size_t i = 0; i < ARRAY_SIZE(channel_cfg); i++) {
+		channel_cfg[i].reference = static_cast<adc_reference>(mode);
+	}
 }
 
-int analogRead(pin_size_t pinNumber)
-{
-  int err;
-  int16_t buf;
-  struct adc_sequence seq = { .buffer = &buf, .buffer_size = sizeof(buf) };
-  size_t idx = analog_pin_index(pinNumber);
+int analogRead(pin_size_t pinNumber) {
+	int err;
+	int16_t buf;
+	struct adc_sequence seq = {.buffer = &buf, .buffer_size = sizeof(buf)};
+	size_t idx = analog_pin_index(pinNumber);
 
-  if (idx >= ARRAY_SIZE(arduino_adc) ) {
-    return -EINVAL;
-  }
+	if (idx >= ARRAY_SIZE(arduino_adc)) {
+		return -EINVAL;
+	}
 
-  /*
-   * ADC that is on MCU supported by Zephyr exists
-   * only 16bit resolution, currently.
-   */
-  if (arduino_adc[idx].resolution > 16) {
-    return -ENOTSUP;
-  }
+	/*
+	 * ADC that is on MCU supported by Zephyr exists
+	 * only 16bit resolution, currently.
+	 */
+	if (arduino_adc[idx].resolution > 16) {
+		return -ENOTSUP;
+	}
 
-  err = adc_channel_setup(arduino_adc[idx].dev, &arduino_adc[idx].channel_cfg);
-  if (err < 0) {
-    return err;
-  }
+	err = adc_channel_setup(arduino_adc[idx].dev, &arduino_adc[idx].channel_cfg);
+	if (err < 0) {
+		return err;
+	}
 
-  seq.channels = BIT(arduino_adc[idx].channel_id);
-  seq.resolution = arduino_adc[idx].resolution;
-  seq.oversampling = arduino_adc[idx].oversampling;
+	seq.channels = BIT(arduino_adc[idx].channel_id);
+	seq.resolution = arduino_adc[idx].resolution;
+	seq.oversampling = arduino_adc[idx].oversampling;
 
-  err = adc_read(arduino_adc[idx].dev, &seq);
-  if (err < 0) {
-    return err;
-  }
+	err = adc_read(arduino_adc[idx].dev, &seq);
+	if (err < 0) {
+		return err;
+	}
 
-  return buf;
+	return buf;
 }
 
 #endif
 
-void attachInterrupt(pin_size_t pinNumber, voidFuncPtr callback, PinStatus pinStatus)
-{
-  struct gpio_port_callback *pcb;
-  gpio_flags_t intmode = 0;
+void attachInterrupt(pin_size_t pinNumber, voidFuncPtr callback, PinStatus pinStatus) {
+	struct gpio_port_callback *pcb;
+	gpio_flags_t intmode = 0;
 
-  if (!callback) {
-    return;
-  }
+	if (!callback) {
+		return;
+	}
 
-  if (pinStatus == LOW) {
-    intmode |= GPIO_INT_LEVEL_LOW;
-  } else if (pinStatus == HIGH) {
-    intmode |= GPIO_INT_LEVEL_HIGH;
-  } else if (pinStatus == CHANGE) {
-    intmode |= GPIO_INT_EDGE_BOTH;
-  } else if (pinStatus == FALLING) {
-    intmode |= GPIO_INT_EDGE_FALLING;
-  } else if (pinStatus == RISING) {
-    intmode |= GPIO_INT_EDGE_RISING;
-  } else {
-    return;
-  }
+	if (pinStatus == LOW) {
+		intmode |= GPIO_INT_LEVEL_LOW;
+	} else if (pinStatus == HIGH) {
+		intmode |= GPIO_INT_LEVEL_HIGH;
+	} else if (pinStatus == CHANGE) {
+		intmode |= GPIO_INT_EDGE_BOTH;
+	} else if (pinStatus == FALLING) {
+		intmode |= GPIO_INT_EDGE_FALLING;
+	} else if (pinStatus == RISING) {
+		intmode |= GPIO_INT_EDGE_RISING;
+	} else {
+		return;
+	}
 
-  pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
-  __ASSERT(pcb != nullptr, "gpio_port_callback not found");
+	pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
+	__ASSERT(pcb != nullptr, "gpio_port_callback not found");
 
-  pcb->pins |= BIT(arduino_pins[pinNumber].pin);
-  setInterruptHandler(pinNumber, callback);
-  enableInterrupt(pinNumber);
+	pcb->pins |= BIT(arduino_pins[pinNumber].pin);
+	setInterruptHandler(pinNumber, callback);
+	enableInterrupt(pinNumber);
 
-  gpio_pin_interrupt_configure(arduino_pins[pinNumber].port, arduino_pins[pinNumber].pin, intmode);
-  gpio_init_callback(&pcb->callback, handleGpioCallback, pcb->pins);
-  gpio_add_callback(arduino_pins[pinNumber].port, &pcb->callback);
+	gpio_pin_interrupt_configure(arduino_pins[pinNumber].port, arduino_pins[pinNumber].pin,
+								 intmode);
+	gpio_init_callback(&pcb->callback, handleGpioCallback, pcb->pins);
+	gpio_add_callback(arduino_pins[pinNumber].port, &pcb->callback);
 }
 
-void detachInterrupt(pin_size_t pinNumber)
-{
-  setInterruptHandler(pinNumber, nullptr);
-  disableInterrupt(pinNumber);
+void detachInterrupt(pin_size_t pinNumber) {
+	setInterruptHandler(pinNumber, nullptr);
+	disableInterrupt(pinNumber);
 }
 
 #ifndef CONFIG_MINIMAL_LIBC_RAND
@@ -500,74 +482,76 @@ long random(long max) {
 #endif
 
 unsigned long pulseIn(pin_size_t pinNumber, uint8_t state, unsigned long timeout) {
-  struct k_timer timer;
-  int64_t start, end, delta = 0;
-  const struct gpio_dt_spec *spec = &arduino_pins[pinNumber];
+	struct k_timer timer;
+	int64_t start, end, delta = 0;
+	const struct gpio_dt_spec *spec = &arduino_pins[pinNumber];
 
-  if (!gpio_is_ready_dt(spec)) {
-    return 0;
-  }
+	if (!gpio_is_ready_dt(spec)) {
+		return 0;
+	}
 
-  k_timer_init(&timer, NULL, NULL);
-  k_timer_start(&timer, K_MSEC(timeout), K_NO_WAIT);
+	k_timer_init(&timer, NULL, NULL);
+	k_timer_start(&timer, K_MSEC(timeout), K_NO_WAIT);
 
-  while(gpio_pin_get_dt(spec) == state && k_timer_status_get(&timer) == 0);
-  if (k_timer_status_get(&timer) > 0) {
-    goto cleanup;
-  }
+	while (gpio_pin_get_dt(spec) == state && k_timer_status_get(&timer) == 0)
+		;
+	if (k_timer_status_get(&timer) > 0) {
+		goto cleanup;
+	}
 
-  while(gpio_pin_get_dt(spec) != state && k_timer_status_get(&timer) == 0);
-  if (k_timer_status_get(&timer) > 0) {
-    goto cleanup;
-  }
+	while (gpio_pin_get_dt(spec) != state && k_timer_status_get(&timer) == 0)
+		;
+	if (k_timer_status_get(&timer) > 0) {
+		goto cleanup;
+	}
 
-  start = k_uptime_ticks();
-  while(gpio_pin_get_dt(spec) == state && k_timer_status_get(&timer) == 0);
-  if (k_timer_status_get(&timer) > 0) {
-    goto cleanup;
-  }
-  end = k_uptime_ticks();
+	start = k_uptime_ticks();
+	while (gpio_pin_get_dt(spec) == state && k_timer_status_get(&timer) == 0)
+		;
+	if (k_timer_status_get(&timer) > 0) {
+		goto cleanup;
+	}
+	end = k_uptime_ticks();
 
-  delta = k_ticks_to_us_floor64(end - start);
+	delta = k_ticks_to_us_floor64(end - start);
 
 cleanup:
-  k_timer_stop(&timer);
-  return (unsigned long)delta;
+	k_timer_stop(&timer);
+	return (unsigned long)delta;
 }
 
 void enableInterrupt(pin_size_t pinNumber) {
-  struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
+	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
-  if (pcb) {
-    pcb->handlers[arduino_pins[pinNumber].pin].enabled = true;
-  }
+	if (pcb) {
+		pcb->handlers[arduino_pins[pinNumber].pin].enabled = true;
+	}
 }
 
 void disableInterrupt(pin_size_t pinNumber) {
-  struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
+	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pinNumber].port);
 
-  if (pcb) {
-    pcb->handlers[arduino_pins[pinNumber].pin].enabled = false;
-  }
+	if (pcb) {
+		pcb->handlers[arduino_pins[pinNumber].pin].enabled = false;
+	}
 }
 
 void interrupts(void) {
-  if (interrupts_disabled) {
-    irq_unlock(irq_key);
-    interrupts_disabled = false;
-  }
+	if (interrupts_disabled) {
+		irq_unlock(irq_key);
+		interrupts_disabled = false;
+	}
 }
 
 void noInterrupts(void) {
-  if (!interrupts_disabled) {
-    irq_key = irq_lock();
-    interrupts_disabled = true;
-  }
+	if (!interrupts_disabled) {
+		irq_key = irq_lock();
+		interrupts_disabled = true;
+	}
 }
 
 int digitalPinToInterrupt(pin_size_t pin) {
-  struct gpio_port_callback *pcb =
-      find_gpio_port_callback(arduino_pins[pin].port);
+	struct gpio_port_callback *pcb = find_gpio_port_callback(arduino_pins[pin].port);
 
-  return (pcb) ? pin : -1;
+	return (pcb) ? pin : -1;
 }

--- a/cores/arduino/zephyrPrint.cpp
+++ b/cores/arduino/zephyrPrint.cpp
@@ -9,18 +9,14 @@
 #include <Arduino.h>
 #include <api/Print.h>
 
-namespace arduino
-{
-namespace zephyr
-{
+namespace arduino {
+namespace zephyr {
 
-int cbprintf_callback(int c, void *ctx)
-{
+int cbprintf_callback(int c, void *ctx) {
 	return reinterpret_cast<arduino::Print *>(ctx)->write((unsigned char)c);
 }
 
-size_t wrap_cbprintf(void *ctx, const char *format, ...)
-{
+size_t wrap_cbprintf(void *ctx, const char *format, ...) {
 	va_list ap;
 	int rc;
 
@@ -31,8 +27,7 @@ size_t wrap_cbprintf(void *ctx, const char *format, ...)
 	return static_cast<size_t>(rc > 0 ? rc : 0);
 }
 
-size_t print_number_base_any(void *ctx, unsigned long long ull, int base)
-{
+size_t print_number_base_any(void *ctx, unsigned long long ull, int base) {
 	arduino::Print &print = *reinterpret_cast<arduino::Print *>(ctx);
 	char string[sizeof(unsigned long long) * 8] = {0};
 	size_t digit = 0;
@@ -47,7 +42,7 @@ size_t print_number_base_any(void *ctx, unsigned long long ull, int base)
 		if (value < 10) {
 			string[sizeof(string) - digit] = '0' + value;
 		} else {
-			string[sizeof(string) - digit] = 'A' + (value- 10);
+			string[sizeof(string) - digit] = 'A' + (value - 10);
 		}
 
 		digit++;
@@ -57,8 +52,7 @@ size_t print_number_base_any(void *ctx, unsigned long long ull, int base)
 	return print.write(string + (sizeof(string) - digit), digit + 1);
 }
 
-size_t print_number_base_pow2(void *ctx, unsigned long long ull, unsigned bits)
-{
+size_t print_number_base_pow2(void *ctx, unsigned long long ull, unsigned bits) {
 	arduino::Print &print = *reinterpret_cast<arduino::Print *>(ctx);
 	const unsigned long long mask = (1 << bits) - 1;
 	int digit = (((sizeof(unsigned long long) * 8) + bits) / bits);
@@ -75,7 +69,7 @@ size_t print_number_base_pow2(void *ctx, unsigned long long ull, unsigned bits)
 			if (value < 10) {
 				print.write('0' + value);
 			} else {
-				print.write('A' + (value- 10));
+				print.write('A' + (value - 10));
 			}
 			output_count++;
 		}
@@ -92,11 +86,10 @@ size_t print_number_base_pow2(void *ctx, unsigned long long ull, unsigned bits)
  * This is the default implementation.
  * It will be overridden by subclassese.
  */
-size_t arduino::Print::write(const uint8_t *buffer, size_t size)
-{
-  size_t i;
-  for (i=0; i<size && write(buffer[i]); i++) {
-  }
+size_t arduino::Print::write(const uint8_t *buffer, size_t size) {
+	size_t i;
+	for (i = 0; i < size && write(buffer[i]); i++) {
+	}
 
-  return i;
+	return i;
 }

--- a/cores/arduino/zephyrPrint.h
+++ b/cores/arduino/zephyrPrint.h
@@ -11,18 +11,16 @@
 #include <Arduino.h>
 #include <api/Print.h>
 
-namespace arduino
-{
-namespace zephyr
-{
+namespace arduino {
+namespace zephyr {
 
 int cbprintf_callback(int c, void *ctx);
 size_t wrap_cbprintf(void *ctx, const char *format, ...);
 size_t print_number_base_any(void *ctx, unsigned long long ull, int base);
 size_t print_number_base_pow2(void *ctx, unsigned long long ull, unsigned bits);
 
-template <class Number> size_t print_number(void *ctx, Number n, const int base, const char *decfmt)
-{
+template <class Number>
+size_t print_number(void *ctx, Number n, const int base, const char *decfmt) {
 	if (base == 0) {
 		return reinterpret_cast<arduino::Print *>(ctx)->write((char)n);
 	} else if (base == 2) {
@@ -46,63 +44,51 @@ template <class Number> size_t print_number(void *ctx, Number n, const int base,
 
 } // namespace arduino
 
-inline size_t arduino::Print::print(const __FlashStringHelper *fsh)
-{
+inline size_t arduino::Print::print(const __FlashStringHelper *fsh) {
 	return write(reinterpret_cast<const char *>(fsh));
 }
 
-inline size_t arduino::Print::print(const String &s)
-{
+inline size_t arduino::Print::print(const String &s) {
 	return write(s.c_str(), s.length());
 }
 
-inline size_t arduino::Print::print(const char str[])
-{
+inline size_t arduino::Print::print(const char str[]) {
 	return write(str);
 }
 
-inline size_t arduino::Print::print(char c)
-{
+inline size_t arduino::Print::print(char c) {
 	return write(c);
 }
 
-inline size_t arduino::Print::print(unsigned char n, int base)
-{
+inline size_t arduino::Print::print(unsigned char n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%hhu");
 }
 
-inline size_t arduino::Print::print(int n, int base)
-{
+inline size_t arduino::Print::print(int n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%d");
 }
 
-inline size_t arduino::Print::print(unsigned int n, int base)
-{
+inline size_t arduino::Print::print(unsigned int n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%u");
 }
 
-inline size_t arduino::Print::print(long n, int base)
-{
+inline size_t arduino::Print::print(long n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%ld");
 }
 
-inline size_t arduino::Print::print(unsigned long n, int base)
-{
+inline size_t arduino::Print::print(unsigned long n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%lu");
 }
 
-inline size_t arduino::Print::print(long long n, int base)
-{
+inline size_t arduino::Print::print(long long n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%lld");
 }
 
-inline size_t arduino::Print::print(unsigned long long n, int base)
-{
+inline size_t arduino::Print::print(unsigned long long n, int base) {
 	return arduino::zephyr::print_number(this, n, base, "%llu");
 }
 
-inline size_t arduino::Print::print(double n, int perception)
-{
+inline size_t arduino::Print::print(double n, int perception) {
 	if (perception < 10) {
 		const char ch_perception = static_cast<char>('0' + perception);
 		const char format[] = {'%', '.', ch_perception, 'f', '\0'};
@@ -114,77 +100,62 @@ inline size_t arduino::Print::print(double n, int perception)
 	}
 }
 
-inline size_t arduino::Print::print(const Printable &printable)
-{
+inline size_t arduino::Print::print(const Printable &printable) {
 	return printable.printTo(*this);
 }
 
-inline size_t arduino::Print::println(const __FlashStringHelper *fsh)
-{
+inline size_t arduino::Print::println(const __FlashStringHelper *fsh) {
 	return print(fsh) + println();
 }
 
-inline size_t arduino::Print::println(const String &s)
-{
+inline size_t arduino::Print::println(const String &s) {
 	return print(s) + println();
 }
 
-inline size_t arduino::Print::println(const char str[])
-{
+inline size_t arduino::Print::println(const char str[]) {
 	return print(str) + println();
 }
 
-inline size_t arduino::Print::println(char c)
-{
+inline size_t arduino::Print::println(char c) {
 	return print(c) + println();
 }
 
-inline size_t arduino::Print::println(unsigned char uc, int base)
-{
+inline size_t arduino::Print::println(unsigned char uc, int base) {
 	return print(uc, base) + println();
 }
 
-inline size_t arduino::Print::println(int i, int base)
-{
+inline size_t arduino::Print::println(int i, int base) {
 	return print(i, base) + println();
 }
 
-inline size_t arduino::Print::println(unsigned int ui, int base)
-{
+inline size_t arduino::Print::println(unsigned int ui, int base) {
 	return print(ui, base) + println();
 }
 
-inline size_t arduino::Print::println(long l, int base)
-{
+inline size_t arduino::Print::println(long l, int base) {
 	return print(l, base) + println();
 }
 
-inline size_t arduino::Print::println(unsigned long ul, int base)
-{
+inline size_t arduino::Print::println(unsigned long ul, int base) {
 	return print(ul, base) + println();
 }
 
-inline size_t arduino::Print::println(long long ll, int base)
-{
+inline size_t arduino::Print::println(long long ll, int base) {
 	return print(ll, base) + println();
 }
 
-inline size_t arduino::Print::println(unsigned long long ull, int base)
-{
+inline size_t arduino::Print::println(unsigned long long ull, int base) {
 	return print(ull, base) + println();
 }
 
-inline size_t arduino::Print::println(double d, int perception)
-{
+inline size_t arduino::Print::println(double d, int perception) {
 	return print(d, perception) + println();
 }
 
-inline size_t arduino::Print::println(const Printable &printable)
-{
+inline size_t arduino::Print::println(const Printable &printable) {
 	return print(printable) + println();
 }
 
-inline size_t arduino::Print::println(void)
-{
+inline size_t arduino::Print::println(void) {
 	return write("\r\n", 2);
 }

--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -10,11 +10,9 @@
 #include <api/HardwareSerial.h>
 #include <zephyrSerial.h>
 
-namespace
-{
+namespace {
 
-enum uart_config_parity conf_parity(uint16_t conf)
-{
+enum uart_config_parity conf_parity(uint16_t conf) {
 	switch (conf & SERIAL_PARITY_MASK) {
 	case SERIAL_PARITY_EVEN:
 		return UART_CFG_PARITY_EVEN;
@@ -25,8 +23,7 @@ enum uart_config_parity conf_parity(uint16_t conf)
 	}
 }
 
-enum uart_config_stop_bits conf_stop_bits(uint16_t conf)
-{
+enum uart_config_stop_bits conf_stop_bits(uint16_t conf) {
 	switch (conf & SERIAL_STOP_BIT_MASK) {
 	case SERIAL_STOP_BIT_1_5:
 		return UART_CFG_STOP_BITS_1_5;
@@ -37,8 +34,7 @@ enum uart_config_stop_bits conf_stop_bits(uint16_t conf)
 	}
 }
 
-enum uart_config_data_bits conf_data_bits(uint16_t conf)
-{
+enum uart_config_data_bits conf_data_bits(uint16_t conf) {
 	switch (conf & SERIAL_DATA_MASK) {
 	case SERIAL_DATA_5:
 		return UART_CFG_DATA_BITS_5;
@@ -53,8 +49,7 @@ enum uart_config_data_bits conf_data_bits(uint16_t conf)
 
 } // anonymous namespace
 
-void arduino::ZephyrSerial::begin(unsigned long baud, uint16_t conf)
-{
+void arduino::ZephyrSerial::begin(unsigned long baud, uint16_t conf) {
 	struct uart_config config = {
 		.baudrate = static_cast<uint32_t>(baud),
 		.parity = conf_parity(conf),
@@ -68,8 +63,7 @@ void arduino::ZephyrSerial::begin(unsigned long baud, uint16_t conf)
 	uart_irq_rx_enable(uart);
 }
 
-void arduino::ZephyrSerial::IrqHandler()
-{
+void arduino::ZephyrSerial::IrqHandler() {
 	uint8_t buf[8];
 	int length;
 	int ret = 0;
@@ -108,13 +102,11 @@ void arduino::ZephyrSerial::IrqHandler()
 	k_sem_give(&tx.sem);
 }
 
-void arduino::ZephyrSerial::IrqDispatch(const struct device *dev, void *data)
-{
+void arduino::ZephyrSerial::IrqDispatch(const struct device *dev, void *data) {
 	reinterpret_cast<ZephyrSerial *>(data)->IrqHandler();
 }
 
-int arduino::ZephyrSerial::available()
-{
+int arduino::ZephyrSerial::available() {
 	int ret;
 
 	k_sem_take(&rx.sem, K_FOREVER);
@@ -124,8 +116,7 @@ int arduino::ZephyrSerial::available()
 	return ret;
 }
 
-int arduino::ZephyrSerial::peek()
-{
+int arduino::ZephyrSerial::peek() {
 	uint8_t data;
 
 	k_sem_take(&rx.sem, K_FOREVER);
@@ -135,8 +126,7 @@ int arduino::ZephyrSerial::peek()
 	return data;
 }
 
-int arduino::ZephyrSerial::read()
-{
+int arduino::ZephyrSerial::read() {
 	uint8_t data;
 
 	k_sem_take(&rx.sem, K_FOREVER);
@@ -146,8 +136,7 @@ int arduino::ZephyrSerial::read()
 	return data;
 }
 
-size_t arduino::ZephyrSerial::write(const uint8_t *buffer, size_t size)
-{
+size_t arduino::ZephyrSerial::write(const uint8_t *buffer, size_t size) {
 	int ret;
 
 	k_sem_take(&tx.sem, K_FOREVER);
@@ -175,13 +164,17 @@ arduino::ZephyrSerial Serial(DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user
 	COND_CODE_1(ARDUINO_SERIAL_DEFINED_##i, (DECL_SERIAL_0(n, p, i)), (DECL_SERIAL_N(n, p, i)))
 
 #define CALL_EVENT_0(n, p, i)
-#define CALL_EVENT_N(n, p, i) if (_CONCAT(Serial, i).available()) _CONCAT(_CONCAT(serial, i), Event)();
-#define CALL_SERIALEVENT_N(n, p, i)                                                               \
+#define CALL_EVENT_N(n, p, i)                                                                      \
+	if (_CONCAT(Serial, i).available())                                                            \
+		_CONCAT(_CONCAT(serial, i), Event)();
+#define CALL_SERIALEVENT_N(n, p, i)                                                                \
 	COND_CODE_1(ARDUINO_SERIAL_DEFINED_##i, (CALL_EVENT_0(n, p, i)), (CALL_EVENT_N(n, p, i)));
 
 #define DECL_EVENT_0(n, p, i)
-#define DECL_EVENT_N(n, p, i) __attribute__((weak)) void serial##i##Event() { }
-#define DECLARE_SERIALEVENT_N(n, p, i)                                                                   \
+#define DECL_EVENT_N(n, p, i)                                                                      \
+	__attribute__((weak)) void serial##i##Event() {                                                \
+	}
+#define DECLARE_SERIALEVENT_N(n, p, i)                                                             \
 	COND_CODE_1(ARDUINO_SERIAL_DEFINED_##i, (DECL_EVENT_0(n, p, i)), (DECL_EVENT_N(n, p, i)));
 
 DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_SERIAL_N)
@@ -193,15 +186,16 @@ arduino::ZephyrSerial Serial(DEVICE_DT_GET(DT_NODELABEL(arduino_serial)));
 arduino::ZephyrSerialStub Serial;
 #endif
 
-
-__attribute__((weak)) void serialEvent() { }
+__attribute__((weak)) void serialEvent() {
+}
 #if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
 DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, DECLARE_SERIALEVENT_N)
 #endif
 
-void arduino::serialEventRun(void)
-{
-	if (Serial.available()) serialEvent();
+void arduino::serialEventRun(void) {
+	if (Serial.available()) {
+		serialEvent();
+	}
 #if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
 	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), serials, CALL_SERIALEVENT_N)
 #endif

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -13,56 +13,82 @@
 
 namespace arduino {
 
-class ZephyrSerialStub : public HardwareSerial
-{
+class ZephyrSerialStub : public HardwareSerial {
 public:
-	void begin(unsigned long baudRate) { }
-	void begin(unsigned long baudrate, uint16_t config) { }
-	void end() { }
-	int available() { return 0; }
-	int peek() { return 0; }
-	int read() { return 0; }
-	void flush() { }
-	size_t write(const uint8_t data)
-	{
+	void begin(unsigned long baudRate) {
+	}
+
+	void begin(unsigned long baudrate, uint16_t config) {
+	}
+
+	void end() {
+	}
+
+	int available() {
+		return 0;
+	}
+
+	int peek() {
+		return 0;
+	}
+
+	int read() {
+		return 0;
+	}
+
+	void flush() {
+	}
+
+	size_t write(const uint8_t data) {
 		printk("%c", static_cast<char>(data));
 		return 1;
 	}
 
-	operator bool() { return true; }
+	operator bool() {
+		return true;
+	}
 };
 
-class ZephyrSerial : public HardwareSerial
-{
+class ZephyrSerial : public HardwareSerial {
 public:
-	template <int SZ>
-	class ZephyrSerialBuffer
-	{
-	      friend arduino::ZephyrSerial;
+	template <int SZ> class ZephyrSerialBuffer {
+		friend arduino::ZephyrSerial;
 		struct ring_buf ringbuf;
 		uint8_t buffer[SZ];
 		struct k_sem sem;
 
-		ZephyrSerialBuffer()
-		{
+		ZephyrSerialBuffer() {
 			k_sem_init(&sem, 1, 1);
 			ring_buf_init(&ringbuf, sizeof(buffer), buffer);
 		}
 	};
 
-	ZephyrSerial(const struct device *dev) : uart(dev) { }
+	ZephyrSerial(const struct device *dev) : uart(dev) {
+	}
+
 	void begin(unsigned long baudrate, uint16_t config);
-	void begin(unsigned long baudrate) { begin(baudrate, SERIAL_8N1); }
-	void flush() { }
-	void end() { }
+
+	void begin(unsigned long baudrate) {
+		begin(baudrate, SERIAL_8N1);
+	}
+
+	void flush() {
+	}
+
+	void end() {
+	}
+
 	size_t write(const uint8_t *buffer, size_t size);
-	size_t write(const uint8_t data) { return write(&data, 1); }
+
+	size_t write(const uint8_t data) {
+		return write(&data, 1);
+	}
+
 	int available();
 	int peek();
 	int read();
 
-	operator bool()
-	{
+	operator bool() {
 		return true;
 	}
 
@@ -75,14 +101,13 @@ protected:
 	ZephyrSerialBuffer<CONFIG_ARDUINO_API_SERIAL_BUFFER_SIZE> rx;
 };
 
-
-}   // namespace arduino
+} // namespace arduino
 
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), serials)
 extern arduino::ZephyrSerial Serial;
 #if (DT_PROP_LEN(DT_PATH(zephyr_user), serials) > 1)
-#define SERIAL_DEFINED_0		 1
-#define EXTERN_SERIAL_N(i)		 extern arduino::ZephyrSerial Serial##i;
+#define SERIAL_DEFINED_0                 1
+#define EXTERN_SERIAL_N(i)               extern arduino::ZephyrSerial Serial##i;
 #define DECLARE_EXTERN_SERIAL_N(n, p, i) COND_CODE_1(SERIAL_DEFINED_##i, (), (EXTERN_SERIAL_N(i)))
 
 /* Declare Serial1, Serial2, ... */


### PR DESCRIPTION
Use a formatter to standardize indentation.

----

Committing to reduce the diff in preparation for the merge.

Please approve #163 and #165 first.