### PR TITLE
Cleanup cores/arduino/commonZephyr.cpp, cores/arduino/Arduino.h

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -35,6 +35,11 @@
 #undef DIGITAL_PIN_CHECK_UNIQUE
 #endif
 
+// Helper macro to get Arduino pin number from device tree alias
+#define DIGITAL_PIN_GPIOS_FIND_NODE(node)                                                          \
+	DIGITAL_PIN_GPIOS_FIND_PIN(DT_REG_ADDR(DT_PHANDLE_BY_IDX(node, gpios, 0)),                     \
+							   DT_PHA_BY_IDX(node, gpios, 0, pin))
+
 /* Return the index of it if matched, oterwise return 0 */
 #define LED_BUILTIN_INDEX_BY_REG_AND_PINNUM(n, p, i, dev, num)                                     \
 	(DIGITAL_PIN_EXISTS(n, p, i, dev, num) ? i : 0)

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/i2c.h>
 
+#if DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios) > 0
 #define DIGITAL_PIN_EXISTS(n, p, i, dev, num)                                                      \
 	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) && (num == DT_PHA_BY_IDX(n, p, i, pin))) ?  \
 		 1 :                                                                                       \
@@ -31,6 +32,7 @@
 #endif
 
 #undef DIGITAL_PIN_CHECK_UNIQUE
+#endif
 
 /* Return the index of it if matched, oterwise return 0 */
 #define LED_BUILTIN_INDEX_BY_REG_AND_PINNUM(n, p, i, dev, num)                                     \
@@ -79,7 +81,9 @@
  * enum digitalPins { D0, D1, ... LED... NUM_OF_DIGITAL_PINS };
  */
 enum digitalPins {
+#if DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios) > 0
 	DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios, DN_ENUMS, (, )),
+#endif
 	NUM_OF_DIGITAL_PINS
 };
 

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -15,10 +15,11 @@
 #include <zephyr/drivers/i2c.h>
 
 #if DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios) > 0
+/* Note: DT_REG_ADDR needs an expanded argument or it will not work properly */
+#define DIGITAL_PIN_MATCHES(dev_pha, pin, dev, num)                                                \
+	(((dev == DT_REG_ADDR(dev_pha)) && (num == pin)) ? 1 : 0)
 #define DIGITAL_PIN_EXISTS(n, p, i, dev, num)                                                      \
-	(((dev == DT_REG_ADDR(DT_PHANDLE_BY_IDX(n, p, i))) && (num == DT_PHA_BY_IDX(n, p, i, pin))) ?  \
-		 1 :                                                                                       \
-		 0)
+	DIGITAL_PIN_MATCHES(DT_PHANDLE_BY_IDX(n, p, i), DT_PHA_BY_IDX(n, p, i, pin), dev, num)
 
 /* Check all pins are defined only once */
 #define DIGITAL_PIN_CHECK_UNIQUE(i, _)                                                             \

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -21,34 +21,33 @@ namespace {
  * Calculate GPIO ports/pins number statically from devicetree configuration
  */
 
-template <class N, class Head> constexpr const N sum_of_list(const N sum, const Head &head) {
+template <class N, class Head> constexpr N sum_of_list(const N sum, const Head &head) {
 	return sum + head;
 }
 
 template <class N, class Head, class... Tail>
-constexpr const N sum_of_list(const N sum, const Head &head, const Tail &...tail) {
+constexpr N sum_of_list(const N sum, const Head &head, const Tail &...tail) {
 	return sum_of_list(sum + head, tail...);
 }
 
-template <class N, class Head> constexpr const N max_in_list(const N max, const Head &head) {
+template <class N, class Head> constexpr N max_in_list(const N max, const Head &head) {
 	return (max >= head) ? max : head;
 }
 
 template <class N, class Head, class... Tail>
-constexpr const N max_in_list(const N max, const Head &head, const Tail &...tail) {
+constexpr N max_in_list(const N max, const Head &head, const Tail &...tail) {
 	return max_in_list((max >= head) ? max : head, tail...);
 }
 
 template <class Query, class Head>
-constexpr const size_t is_first_appearance(const size_t &idx, const size_t &at, const size_t &found,
-										   const Query &query, const Head &head) {
+constexpr size_t is_first_appearance(const size_t &idx, const size_t &at, const size_t &found,
+									 const Query &query, const Head &head) {
 	return ((found == ((size_t)-1)) && (query == head) && (idx == at)) ? 1 : 0;
 }
 
 template <class Query, class Head, class... Tail>
-constexpr const size_t is_first_appearance(const size_t &idx, const size_t &at, const size_t &found,
-										   const Query &query, const Head &head,
-										   const Tail &...tail) {
+constexpr size_t is_first_appearance(const size_t &idx, const size_t &at, const size_t &found,
+									 const Query &query, const Head &head, const Tail &...tail) {
 	return ((found == ((size_t)-1)) && (query == head) && (idx == at)) ?
 			   1 :
 			   is_first_appearance(idx + 1, at, (query == head ? idx : found), query, tail...);
@@ -112,6 +111,7 @@ void setInterruptHandler(pin_size_t pinNumber, voidFuncPtr func) {
 }
 
 void handleGpioCallback(const struct device *port, struct gpio_callback *cb, uint32_t pins) {
+	(void)port; // unused
 	struct gpio_port_callback *pcb = (struct gpio_port_callback *)cb;
 
 	for (uint32_t i = 0; i < max_ngpios; i++) {

--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -15,6 +15,8 @@ static const struct gpio_dt_spec arduino_pins[] = {
 
 namespace {
 
+#if DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios) > 0
+
 /*
  * Calculate GPIO ports/pins number statically from devicetree configuration
  */
@@ -63,6 +65,13 @@ const int port_num = sum_of_list(
 #define GPIO_NGPIOS(n, p, i) DT_PROP(DT_GPIO_CTLR_BY_IDX(n, p, i), ngpios)
 const int max_ngpios = max_in_list(
 	0, DT_FOREACH_PROP_ELEM_SEP(DT_PATH(zephyr_user), digital_pin_gpios, GPIO_NGPIOS, (, )));
+
+#else
+
+const int port_num = 1;
+const int max_ngpios = 0;
+
+#endif
 
 /*
  * GPIO callback implementation


### PR DESCRIPTION
Merge following fix from https://github.com/arduino/ArduinoCore-zephyr/.

- Add condition branching when digital_pins_gpios has no entry
- Fix edge case macro expansion failure
- Add pin find helper macro
- Fix warnings in zephyrCommon.cpp