### PR TITLE
Wire: improve code, add safety checks, add basic logging

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -41,4 +41,9 @@ config ARDUINO_MAX_TONES
 	  Specify the maximum number of tones that can be played simultaneously with tone().
 	  If set to a negative value, the maximum number will be determined from the
 	  system's digital pin configuration.
+
+module = ARDUINO_API
+module-str = arduino_api
+source "subsys/logging/Kconfig.template.log_config"
+
 endif

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -7,6 +7,9 @@
 #include <Wire.h>
 #include <zephyr/sys/util_macro.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(arduino_wire, CONFIG_ARDUINO_API_LOG_LEVEL);
+
 arduino::ZephyrI2C::ZephyrI2C(const struct device *i2c) : i2c_dev(i2c)
 {
 }
@@ -45,12 +48,14 @@ size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len,
   /* Use stack-allocated buffer for reading */
   uint8_t readbuff[sizeof(rxRingBuffer.buffer)];
   if (len > sizeof(readbuff)) {
+    LOG_ERR("requested read length (%zu) exceeds buffer size (%zu)", len, sizeof(readbuff));
     return 0;
   }
 
   int ret = i2c_read(i2c_dev, readbuff, len, address);
   if (ret != 0)
   {
+    LOG_ERR("burst read failed");
     return 0;
   }
 
@@ -59,6 +64,7 @@ size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len,
   ret = ring_buf_put(&rxRingBuffer.rb, readbuff, len);
   if (ret == 0)
   {
+    LOG_ERR("failed to put data in ring buffer");
     return 0;
   }
   return len;
@@ -70,6 +76,7 @@ size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len) { // TODO fo
 
 size_t arduino::ZephyrI2C::write(uint8_t data) {  // TODO for ADS1115
   if (usedTxBuffer >= sizeof(txBuffer)) {
+    LOG_ERR("tx buffer is full");
     return 0;
   }
   txBuffer[usedTxBuffer++] = data;
@@ -89,6 +96,7 @@ int arduino::ZephyrI2C::read() {
   uint8_t buf[1];
 
   if(!ring_buf_get(&rxRingBuffer.rb, buf, 1)) {
+    LOG_ERR("buffer is empty");
     return -1; // no data available
   }
 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -42,19 +42,23 @@ uint8_t arduino::ZephyrI2C::endTransmission(void) { // TODO for ADS1115
 
 size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len,
                                        bool stopBit) {
-  int ret = i2c_read(i2c_dev, rxRingBuffer.buffer, len, address);
+  /* Use stack-allocated buffer for reading */
+  uint8_t readbuff[sizeof(rxRingBuffer.buffer)];
+  if (len > sizeof(readbuff)) {
+    return 0;
+  }
+
+  int ret = i2c_read(i2c_dev, readbuff, len, address);
   if (ret != 0)
   {
-    printk("\n\nERR: i2c burst read fails\n\n\n");
     return 0;
   }
 
   /* Flush the receive buffer so another read() call returns the correct data */
   flush();
-  ret = ring_buf_put(&rxRingBuffer.rb, rxRingBuffer.buffer, len);
+  ret = ring_buf_put(&rxRingBuffer.rb, readbuff, len);
   if (ret == 0)
   {
-    printk("\n\nERR: buff put fails\n\n\n");
     return 0;
   }
   return len;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -80,15 +80,12 @@ size_t arduino::ZephyrI2C::write(const uint8_t *buffer, size_t size) {
 
 int arduino::ZephyrI2C::read() {
   uint8_t buf[1];
-  if (ring_buf_peek(&rxRingBuffer.rb, buf, 1) > 0) {
-        int ret = ring_buf_get(&rxRingBuffer.rb, buf, 1);
-        if (ret == 0) {
-          printk("\n\nERR: buff empty\n\n\n");
-            return 0;
-        }
-		return (int)buf[0];
+
+  if(!ring_buf_get(&rxRingBuffer.rb, buf, 1)) {
+    return -1; // no data available
   }
-  return EXIT_FAILURE;
+
+  return (int)buf[0];
 }
 
 int arduino::ZephyrI2C::available() { // TODO for ADS1115 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -69,6 +69,9 @@ size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len) { // TODO fo
 }
 
 size_t arduino::ZephyrI2C::write(uint8_t data) {  // TODO for ADS1115
+  if (usedTxBuffer >= sizeof(txBuffer)) {
+    return 0;
+  }
   txBuffer[usedTxBuffer++] = data;
   return 1;
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -48,6 +48,9 @@ size_t arduino::ZephyrI2C::requestFrom(uint8_t address, size_t len,
     printk("\n\nERR: i2c burst read fails\n\n\n");
     return 0;
   }
+
+  /* Flush the receive buffer so another read() call returns the correct data */
+  flush();
   ret = ring_buf_put(&rxRingBuffer.rb, rxRingBuffer.buffer, len);
   if (ret == 0)
   {
@@ -101,7 +104,9 @@ int arduino::ZephyrI2C::peek() {
   return (int)buf[0];
 }
 
-void arduino::ZephyrI2C::flush() {}
+void arduino::ZephyrI2C::flush() {
+  ring_buf_reset(&rxRingBuffer.rb);
+}
 
 void arduino::ZephyrI2C::onReceive(voidFuncPtrParamInt cb) {}
 void arduino::ZephyrI2C::onRequest(voidFuncPtr cb) {}

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -98,10 +98,10 @@ int arduino::ZephyrI2C::available() { // TODO for ADS1115
 
 int arduino::ZephyrI2C::peek() {
   uint8_t buf[1];
-  int bytes_read = ring_buf_peek(&rxRingBuffer.rb, buf, 1);
-  if (bytes_read == 0){
-    return 0;
-  } 
+  if (!ring_buf_peek(&rxRingBuffer.rb, buf, 1)){
+    // No data available
+    return -1;
+  }
   return (int)buf[0];
 }
 


### PR DESCRIPTION
This PR fixes and changes a few things related to the `wire` port of the Arduino library. All changes are done in separate commits for readability. The most important functions changed are the `arduino::ZephyrI2C::requestFrom()` and `arduino::ZephyrI2C::read()`.

Additionally, the `ARDUINO_API` log module/levels have been added enabling an user to control the log level of logs in this repository. As an example, `printk()` calls have been switched with the `LOG_*` API. 