### PR TITLE
variants: Add initial native_sim support

### DIFF
--- a/variants/native_sim/native_sim.overlay
+++ b/variants/native_sim/native_sim.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Dhruva Gole <d-gole@ti.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		digital-pin-gpios = <&gpio0 0 0>,
+				    <&gpio0 1 0>,
+				    <&gpio0 2 0>,
+				    <&gpio0 3 0>,
+				    <&gpio0 4 0>,
+				    <&gpio0 5 0>,
+				    <&gpio0 6 0>,
+				    <&gpio0 7 0>;
+		builtin-led-gpios = <&gpio0 0 0>;
+		serials = <&uart0>;
+	};
+};


### PR DESCRIPTION
Add variants/native_sim/ with native_sim.overlay and native_sim_pinmap.h to support the native_sim board (renamed from native_posix in Zephyr).

native_sim support enables:
- CI/testing without requiring physical hardware
- Rapid development iteration on host machine
- Debugging Arduino API implementations with native toolchains
- Verifying devicetree overlays and pin mappings in simulation
- Running samples like hello_arduino locally before flashing targets