### PR TITLE
Fix micros() for nano without breaking giga

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -347,7 +347,11 @@ void delayMicroseconds(unsigned int us) {
 }
 
 unsigned long micros(void) {
+#ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
+	return k_cyc_to_us_floor32(k_cycle_get_64());
+#else
 	return k_cyc_to_us_floor32(k_cycle_get_32());
+#endif
 }
 
 unsigned long millis(void) {


### PR DESCRIPTION
The rollover fix for the giga used the 64 bit timer instead of 32 bits.  The nano does not have a 64 bit timer, so you need to use the 32 bit instead.

So I know check to see if the processor supports 64 bits if so use it else fall back to 32 bit.

Note: This branch doesn't include support for Arduino Giga,
      but we'll include it as it's a reasonable solution for
      preventing timer overflows.