### PR TITLE
analogWrite: add digitalWrite fallback for analogWrite without PWM

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -436,10 +436,14 @@ void analogWrite(pin_size_t pinNumber, int value) {
 	size_t idx = pwm_pin_index(pinNumber);
 
 	if (idx >= ARRAY_SIZE(arduino_pwm)) {
+		pinMode(pinNumber, OUTPUT);
+		digitalWrite(pinNumber, value > 127 ? HIGH : LOW);
 		return;
 	}
 
 	if (!pwm_is_ready_dt(&arduino_pwm[idx])) {
+		pinMode(pinNumber, OUTPUT);
+		digitalWrite(pinNumber, value > 127 ? HIGH : LOW);
 		return;
 	}
 


### PR DESCRIPTION
When analogWrite() is called for a pin that cannot be resolved to a PWM channel,
or when the resolved PWM device is not ready,
fall back to GPIO output instead of returning without changing the pin state.

This matches the common Arduino behavior for pins without hardware PWM support:
values above the midpoint drive the pin HIGH,
while lower values drive it LOW. Existing hardware PWM behavior is unchanged.