### PR TITLE
libraries: Wire: Compile only CONFIG_I2C enabled

### DIFF
--- a/libraries/Wire/CMakeLists.txt
+++ b/libraries/Wire/CMakeLists.txt
@@ -3,6 +3,6 @@ zephyr_include_directories(.)
 
 if(NOT DEFINED ARDUINO_BUILD_PATH)
 
-zephyr_sources(Wire.cpp)
+zephyr_sources_ifdef(CONFIG_I2C Wire.cpp)
 
 endif()


### PR DESCRIPTION
Compiling Wire.cpp only if CONFIG_I2C enabled.