### PR TITLE
core: Add peripheral reinit for pinmux switching

### DIFF
--- a/cores/arduino/zephyrCommon.cpp
+++ b/cores/arduino/zephyrCommon.cpp
@@ -9,6 +9,19 @@
 
 #include <zephyr/spinlock.h>
 
+// create an array of arduino_pins with functions to reinitialize pins if needed
+static const struct device *pinmux_array[DT_PROP_LEN(DT_PATH(zephyr_user), digital_pin_gpios)] = {
+	nullptr};
+
+void _reinit_peripheral_if_needed(pin_size_t pin, const struct device *dev) {
+	if (pinmux_array[pin] != dev) {
+		pinmux_array[pin] = dev;
+		if (dev != NULL) {
+			dev->ops.init(dev);
+		}
+	}
+}
+
 static const struct gpio_dt_spec arduino_pins[] = {
 	DT_FOREACH_PROP_ELEM_SEP(
 	DT_PATH(zephyr_user), digital_pin_gpios, GPIO_DT_SPEC_GET_BY_IDX, (, ))};
@@ -238,6 +251,7 @@ int digitalPinToPinIndex(pin_size_t pinNumber) {
 void pinMode(pin_size_t pinNumber, PinMode pinMode) {
 	RETURN_ON_INVALID_PIN(pinNumber);
 
+	_reinit_peripheral_if_needed(pinNumber, NULL);
 	if (pinMode == INPUT) { // input mode
 		gpio_pin_configure_dt(&arduino_pins[pinNumber], GPIO_INPUT | GPIO_ACTIVE_HIGH);
 	} else if (pinMode == INPUT_PULLUP) { // input with internal pull-up
@@ -478,6 +492,7 @@ void analogWrite(pin_size_t pinNumber, int value) {
 		return;
 	}
 
+	_reinit_peripheral_if_needed(pinNumber, arduino_pwm[idx].dev);
 	value = CLAMP(value, 0, maxInput);
 
 	const uint32_t pulse = map64(value, 0, maxInput, 0, arduino_pwm[idx].period);
@@ -506,6 +521,9 @@ void analogWrite(enum dacPins dacName, int value) {
 			return;
 		}
 
+		// TODO: add reverse map to find pin name from DAC* define
+		// In the meantime, consider A0 == DAC0
+		_reinit_peripheral_if_needed((pin_size_t)(dacName + A0), dac_dev);
 		ret = dac_channel_setup(dac_dev, &dac_ch_cfg[dacName]);
 		if (ret != 0) {
 			return;
@@ -567,6 +585,8 @@ int analogRead(pin_size_t pinNumber) {
 	if (arduino_adc[idx].resolution > 16) {
 		return -ENOTSUP;
 	}
+
+	_reinit_peripheral_if_needed(pinNumber, arduino_adc[idx].dev);
 
 	err = adc_channel_setup(arduino_adc[idx].dev, &arduino_adc[idx].channel_cfg);
 	if (err < 0) {

--- a/cores/arduino/zephyrInternal.h
+++ b/cores/arduino/zephyrInternal.h
@@ -14,6 +14,7 @@ extern "C" {
 
 void enableInterrupt(pin_size_t);
 void disableInterrupt(pin_size_t);
+void _reinit_peripheral_if_needed(pin_size_t pin, const struct device *dev);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cores/arduino/zephyrSerial.cpp
+++ b/cores/arduino/zephyrSerial.cpp
@@ -58,6 +58,8 @@ void arduino::ZephyrSerial::begin(unsigned long baud, uint16_t conf) {
 		.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
 	};
 
+	uart->ops.init(uart);
+
 	uart_configure(uart, &config);
 	uart_irq_callback_user_data_set(uart, arduino::ZephyrSerial::IrqDispatch, this);
 	uart_irq_rx_enable(uart);

--- a/cores/arduino/zephyrSerial.h
+++ b/cores/arduino/zephyrSerial.h
@@ -76,6 +76,11 @@ public:
 	}
 
 	void end() {
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
+		if (uart->ops.deinit) {
+			uart->ops.deinit(uart);
+		}
+#endif
 	}
 
 	size_t write(const uint8_t *buffer, size_t size);

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -118,9 +118,15 @@ void arduino::ZephyrSPI::detachInterrupt() {
 }
 
 void arduino::ZephyrSPI::begin() {
+	spi_dev->ops.init(spi_dev);
 }
 
 void arduino::ZephyrSPI::end() {
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
+	if (spi_dev->ops.deinit) {
+		spi_dev->ops.deinit(spi_dev);
+	}
+#endif
 }
 
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), spis)

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -15,12 +15,18 @@ arduino::ZephyrI2C::ZephyrI2C(const struct device *i2c) : i2c_dev(i2c) {
 
 void arduino::ZephyrI2C::begin() {
 	ring_buf_init(&rxRingBuffer.rb, sizeof(rxRingBuffer.buffer), rxRingBuffer.buffer);
+	i2c_dev->ops.init(i2c_dev);
 }
 
 void arduino::ZephyrI2C::begin(uint8_t slaveAddr) {
 }
 
 void arduino::ZephyrI2C::end() {
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
+	if (i2c_dev->ops.deinit) {
+		i2c_dev->ops.deinit(i2c_dev);
+	}
+#endif
 }
 
 void arduino::ZephyrI2C::setClock(uint32_t freq) {


### PR DESCRIPTION
Allows Arduino APIs to switch a pin between GPIO and peripheral functions by re-running the selected device init path when the requested owner changes.

This is an interim pinmux handoff mechanism for boards where sketches may move a pin back and forth between serial/GPIO/PWM-style use.

**In practice, this code is temporary fix.
Here, for merge management purposes, it's made identical to Arduino, but
the next patch, https://github.com/zephyrproject-rtos/ArduinoCore-zephyr/pull/186, will make this switchable.**