### PR TITLE
treewide: fix SPDX tags on existing files

### DIFF
--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		digital-pin-gpios = <&arduino_nano_header 0 0>,

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr/dt-bindings/adc/adc.h>
 
 / {

--- a/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
+++ b/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		digital-pin-gpios = <&arduino_header 6 0>,	/* Digital */

--- a/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.overlay
+++ b/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.overlay
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		digital-pin-gpios = 


### PR DESCRIPTION
Explicitly state the license in all source files to comply with SPDX best practices. In addition, update the copyright notice to the new format.

Note: Cherry-picked only copyright updates.