### PR TITLE
core: Add variant and loop hooks to Arduino main

### DIFF
--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -5,16 +5,38 @@
  */
 
 #include "Arduino.h"
+#include "zephyr/kernel.h"
+#include <cstdint>
+#ifdef CONFIG_LLEXT
+#include <zephyr/llext/symbol.h>
+#endif
+
+// This function will be overwriten by most variants.
+void __attribute__((weak)) initVariant(void) {
+}
+
+// This function can be overwriten by one library.
+void __attribute__((weak)) __loopHook(void) {
+}
 
 int main(void) {
+	initVariant();
+
 	setup();
 
 	for (;;) {
 		loop();
+#if ZARD_GENERIC_SERIAL_COUNT > 0
 		if (arduino::serialEventRun) {
 			arduino::serialEventRun();
 		}
+#endif
+		__loopHook();
 	}
 
 	return 0;
 }
+
+#ifdef CONFIG_LLEXT
+LL_EXTENSION_SYMBOL(main);
+#endif


### PR DESCRIPTION
Call the weak initVariant() hook before setup() so board variants can run their initialization code from the common Arduino entry point.

Add a weak __loopHook() call after each loop() iteration, guard serialEventRun() when no generic serial devices exist, and export main() for LLEXT builds.