### PR TITLE
variants: Restore removed empty variant.h

### DIFF
--- a/variants/arduino_mkrzero/variant.h
+++ b/variants/arduino_mkrzero/variant.h
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/variants/nrf52840dk_nrf52840/variant.h
+++ b/variants/nrf52840dk_nrf52840/variant.h
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2022 Mike Szczys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/variants/pocketbeagle_2_am6254_a53/variant.h
+++ b/variants/pocketbeagle_2_am6254_a53/variant.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Ayush Singh <ayush@beagleboard.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once

--- a/variants/rpi_pico/variant.h
+++ b/variants/rpi_pico/variant.h
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */


### PR DESCRIPTION
It was removed it in 2044d497, but I am reverting the change because it actually makes management more complicated.